### PR TITLE
Mixed server mode for H2

### DIFF
--- a/celesta-core/src/main/java/ru/curs/celesta/AppSettings.java
+++ b/celesta-core/src/main/java/ru/curs/celesta/AppSettings.java
@@ -8,206 +8,220 @@ import java.util.logging.*;
  * Класс, хранящий параметры приложения. Разбирает .properties-файл.
  */
 public final class AppSettings {
-  private static final String DEFAULT_PYLIB_PATH = "pylib";
+    private static final String DEFAULT_PYLIB_PATH = "pylib";
 
-  private final Properties properties;
+    private final Properties properties;
 
-  private final String scorePath;
-  private final DBType dbType;
-  private final String databaseConnection;
-  private final boolean h2InMemory;
-  private final boolean h2ReferentialIntegrity;
-  private final String login;
-  private final String password;
-  private final Logger logger;
-  private final String pylibPath;
-  private final String javalibPath;
-  private final boolean skipDBUpdate;
-  private final boolean forceDBInitialize;
-  private final boolean logLogins;
+    private final String scorePath;
+    private final DBType dbType;
+    private final String databaseConnection;
+    private final boolean h2InMemory;
+    private final boolean h2ReferentialIntegrity;
+    private final int h2Port;
+    private final String login;
+    private final String password;
+    private final Logger logger;
+    private final String pylibPath;
+    private final String javalibPath;
+    private final boolean skipDBUpdate;
+    private final boolean forceDBInitialize;
+    private final boolean logLogins;
 
-  {
-    logger = Logger.getLogger("ru.curs.flute");
-    logger.setLevel(Level.INFO);
-  }
-
-  public AppSettings(Properties properties) throws CelestaException {
-    this.properties = properties;
-
-    StringBuffer sb = new StringBuffer();
-
-    // Read the settings and check them as thoroughly as possible at this
-    // point.
-
-    scorePath = properties.getProperty("score.path", "").trim();
-    if (scorePath.isEmpty())
-      sb.append("No score path given (score.path).\n");
-    else {
-      checkEntries(scorePath, "score.path", sb);
+    {
+        logger = Logger.getLogger("ru.curs.flute");
+        logger.setLevel(Level.INFO);
     }
 
+    public AppSettings(Properties properties) throws CelestaException {
+        this.properties = properties;
 
-    h2ReferentialIntegrity = Boolean.parseBoolean(properties.getProperty("h2.referential.integrity", "false"));
-    h2InMemory = Boolean.parseBoolean(properties.getProperty("h2.in-memory", "false"));
+        StringBuffer sb = new StringBuffer();
 
-    //Если настройка h2.in-memory установлена в true - игнорируем настройку строки jdbc подключения и вводим свою
-    if (h2InMemory) {
-      databaseConnection = "jdbc:h2:mem:celesta;DB_CLOSE_DELAY=-1";
-      login = "";
-      password = "";
-    } else {
-      String url = properties.getProperty("database.connection", "").trim();
-      if ("".equals(url))
-        url = properties.getProperty("rdbms.connection.url", "").trim();
-      databaseConnection = url;
-      login = properties.getProperty("rdbms.connection.username", "").trim();
-      password = properties.getProperty("rdbms.connection.password", "").trim();
+        // Read the settings and check them as thoroughly as possible at this
+        // point.
 
-      if ("".equals(databaseConnection))
-        sb.append("No JDBC URL given (rdbms.connection.url).\n");
-    }
-
-    dbType = DBType.resolveByJdbcUrl(databaseConnection);
-    if (dbType == DBType.UNKNOWN)
-      sb.append("Cannot recognize RDBMS type or unsupported database.");
-
-    String lf = properties.getProperty("log.file");
-    if (lf != null)
-      try {
-        FileHandler fh = new FileHandler(lf, true);
-        fh.setFormatter(new SimpleFormatter());
-        logger.addHandler(fh);
-      } catch (IOException e) {
-        sb.append("Could not access or create log file " + lf + '\n');
-      }
-
-    pylibPath = properties.getProperty("pylib.path", DEFAULT_PYLIB_PATH).trim();
-    checkEntries(pylibPath, "pylib.path", sb);
-
-    javalibPath = properties.getProperty("javalib.path", "").trim();
-    checkEntries(javalibPath, "javalib.path", sb);
-
-    skipDBUpdate = Boolean.parseBoolean(properties.getProperty("skip.dbupdate", "").trim());
-    forceDBInitialize = Boolean.parseBoolean(properties.getProperty("force.dbinitialize", "").trim());
-    logLogins = Boolean.parseBoolean(properties.getProperty("log.logins", "").trim());
-
-    if (sb.length() > 0)
-      throw new CelestaException(sb.toString());
-
-  }
-
-  private static void checkEntries(String path, String propertyName, StringBuffer sb) {
-    if (!path.isEmpty())
-      for (String pathEntry : path.split(File.pathSeparator)) {
-        File pathFile = new File(pathEntry);
-        if (!(pathFile.isDirectory() && pathFile.canRead())) {
-          sb.append(String.format("Invalid %s entry: %s%n", propertyName, pathEntry));
+        scorePath = properties.getProperty("score.path", "").trim();
+        if (scorePath.isEmpty())
+            sb.append("No score path given (score.path).\n");
+        else {
+            checkEntries(scorePath, "score.path", sb);
         }
-      }
-  }
 
 
+        h2ReferentialIntegrity = Boolean.parseBoolean(properties.getProperty("h2.referential.integrity", "false"));
+        h2InMemory = Boolean.parseBoolean(properties.getProperty("h2.in-memory", "false"));
+        int h2PortTmp = 0;
+        try {
+            h2PortTmp = Integer.parseInt(properties.getProperty("h2.port", "0"));
+        } catch (NumberFormatException e) {
+            sb.append("h2.port should contain a port number.\n");
+        }
+        h2Port = h2PortTmp;
+        //Если настройка h2.in-memory установлена в true - игнорируем настройку строки jdbc подключения и вводим свою
+        if (h2InMemory) {
+            if (h2Port > 0){
+                databaseConnection = String.format(
+                        "jdbc:h2:tcp://localhost:%d/mem:celesta", h2Port);
+            } else {
+                databaseConnection = "jdbc:h2:mem:celesta;DB_CLOSE_DELAY=-1";
+            }
+            login = "";
+            password = "";
+        } else {
+            String url = properties.getProperty("database.connection", "").trim();
+            if ("".equals(url))
+                url = properties.getProperty("rdbms.connection.url", "").trim();
+            databaseConnection = url;
+            login = properties.getProperty("rdbms.connection.username", "").trim();
+            password = properties.getProperty("rdbms.connection.password", "").trim();
+
+            if ("".equals(databaseConnection))
+                sb.append("No JDBC URL given (rdbms.connection.url).\n");
+        }
+
+        dbType = DBType.resolveByJdbcUrl(databaseConnection);
+        if (dbType == DBType.UNKNOWN)
+            sb.append("Cannot recognize RDBMS type or unsupported database.");
+
+        String lf = properties.getProperty("log.file");
+        if (lf != null)
+            try {
+                FileHandler fh = new FileHandler(lf, true);
+                fh.setFormatter(new SimpleFormatter());
+                logger.addHandler(fh);
+            } catch (IOException e) {
+                sb.append("Could not access or create log file ").append(lf).append('\n');
+            }
+
+        pylibPath = properties.getProperty("pylib.path", DEFAULT_PYLIB_PATH).trim();
+        checkEntries(pylibPath, "pylib.path", sb);
+
+        javalibPath = properties.getProperty("javalib.path", "").trim();
+        checkEntries(javalibPath, "javalib.path", sb);
+
+        skipDBUpdate = Boolean.parseBoolean(properties.getProperty("skip.dbupdate", "").trim());
+        forceDBInitialize = Boolean.parseBoolean(properties.getProperty("force.dbinitialize", "").trim());
+        logLogins = Boolean.parseBoolean(properties.getProperty("log.logins", "").trim());
+
+        if (sb.length() > 0)
+            throw new CelestaException(sb.toString());
+
+    }
+
+    private static void checkEntries(String path, String propertyName, StringBuffer sb) {
+        if (!path.isEmpty())
+            for (String pathEntry : path.split(File.pathSeparator)) {
+                File pathFile = new File(pathEntry);
+                if (!(pathFile.isDirectory() && pathFile.canRead())) {
+                    sb.append(String.format("Invalid %s entry: %s%n", propertyName, pathEntry));
+                }
+            }
+    }
 
 
-  /**
-   * Возвращает тип базы данных на основе JDBC-строки подключения.
-   */
-  public DBType getDBType() {
-    return dbType;
-  }
+    /**
+     * Возвращает тип базы данных на основе JDBC-строки подключения.
+     */
+    public DBType getDBType() {
+        return dbType;
+    }
 
-  /**
-   * Возвращает логгер, в который можно записывать сообщения.
-   */
-  public Logger getLogger() {
-    return logger;
-  }
+    /**
+     * Возвращает логгер, в который можно записывать сообщения.
+     */
+    public Logger getLogger() {
+        return logger;
+    }
 
-  /**
-   * Значение параметра "pylib.path".
-   */
-  public String getPylibPath() {
-    return pylibPath;
-  }
+    /**
+     * Значение параметра "pylib.path".
+     */
+    public String getPylibPath() {
+        return pylibPath;
+    }
 
-  /**
-   * Значение параметра "javalib.path".
-   */
+    /**
+     * Значение параметра "javalib.path".
+     */
 
-  public String getJavalibPath() {
-    return javalibPath;
-  }
+    public String getJavalibPath() {
+        return javalibPath;
+    }
 
-  /**
-   * Значение параметра "пропускать фазу обновления базы данных".
-   */
-  public boolean getSkipDBUpdate() {
-    return skipDBUpdate;
-  }
+    /**
+     * Значение параметра "пропускать фазу обновления базы данных".
+     */
+    public boolean getSkipDBUpdate() {
+        return skipDBUpdate;
+    }
 
-  /**
-   * Значение параметра "заставлять обновлять непустую базу данных".
-   */
-  public boolean getForceDBInitialize() {
-    return forceDBInitialize;
-  }
+    /**
+     * Значение параметра "заставлять обновлять непустую базу данных".
+     */
+    public boolean getForceDBInitialize() {
+        return forceDBInitialize;
+    }
 
-  /**
-   * Значение параметра "логировать входы и выходы пользователей".
-   */
-  public boolean getLogLogins() {
-    return logLogins;
-  }
+    /**
+     * Значение параметра "логировать входы и выходы пользователей".
+     */
+    public boolean getLogLogins() {
+        return logLogins;
+    }
 
-  /**
-   * Значение параметра "score.path".
-   */
-  public String getScorePath() {
-    return scorePath;
-  }
+    /**
+     * Значение параметра "score.path".
+     */
+    public String getScorePath() {
+        return scorePath;
+    }
 
-  /**
-   * Значение параметра "Класс JDBC-подключения".
-   */
-  public String getDbClassName() {
-    return dbType.getDriverClassName();
-  }
+    /**
+     * Значение параметра "Класс JDBC-подключения".
+     */
+    public String getDbClassName() {
+        return dbType.getDriverClassName();
+    }
 
-  /**
-   * Значение параметра "Строка JDBC-подключения".
-   */
-  public String getDatabaseConnection() {
-    return databaseConnection;
-  }
+    /**
+     * Значение параметра "Строка JDBC-подключения".
+     */
+    public String getDatabaseConnection() {
+        return databaseConnection;
+    }
 
-  /**
-   * Флаг поддержки для uniq constraint (отключение позволяет, например,
-   * вставлять записи без наличия ссылок на обязательные внешние записи)
-   */
-  public boolean isH2ReferentialIntegrity() {
-    return h2ReferentialIntegrity;
-  }
+    /**
+     * Флаг поддержки для uniq constraint (отключение позволяет, например,
+     * вставлять записи без наличия ссылок на обязательные внешние записи)
+     */
+    public boolean isH2ReferentialIntegrity() {
+        return h2ReferentialIntegrity;
+    }
 
-  /**
-   * Логин к базе данных.
-   */
-  public String getDBLogin() {
-    return login;
-  }
+    /**
+     * Логин к базе данных.
+     */
+    public String getDBLogin() {
+        return login;
+    }
 
-  /**
-   * Пароль к базе данных.
-   */
-  public String getDBPassword() {
-    return password;
-  }
+    /**
+     * Пароль к базе данных.
+     */
+    public String getDBPassword() {
+        return password;
+    }
 
-  /**
-   * Возвращает свойства, с которыми была инициализирована Челеста. Внимание:
-   * данный объект имеет смысл использовать только на чтение, динамическое
-   * изменение этих свойств не приводит ни к чему.
-   */
-  public Properties getSetupProperties() {
-    return properties;
-  }
+    /**
+     * Возвращает свойства, с которыми была инициализирована Челеста. Внимание:
+     * данный объект имеет смысл использовать только на чтение, динамическое
+     * изменение этих свойств не приводит ни к чему.
+     */
+    public Properties getSetupProperties() {
+        return properties;
+    }
+
+    public int getH2Port() {
+        return h2Port;
+    }
 }

--- a/celesta-core/src/main/java/ru/curs/celesta/Celesta.java
+++ b/celesta-core/src/main/java/ru/curs/celesta/Celesta.java
@@ -51,6 +51,7 @@ import java.util.concurrent.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.h2.tools.Server;
 import org.python.core.PyException;
 import org.python.core.PyObject;
 import org.python.util.PythonInterpreter;
@@ -70,597 +71,599 @@ import ru.curs.celesta.score.discovery.PyScoreDiscovery;
  * Корневой класс приложения.
  */
 public final class Celesta implements AutoCloseable {
-	private static final String FILE_PROPERTIES = "celesta.properties";
-	private static final Pattern PROCNAME = Pattern
-			.compile("\\s*([A-Za-z][A-Za-z0-9]*)((\\.[A-Za-z_]\\w*)+)\\.([A-Za-z_]\\w*)\\s*");
-
-	private static final TriggerDispatcher triggerDispatcher = new TriggerDispatcher();
-
-	private final Score score;
-	private final DBAdaptor dbAdaptor;
-	private final AppSettings appSettings;
-	final ConnectionPool connectionPool;
-	private final PythonInterpreterPool interpreterPool;
-	private final Optional<SessionLogManager> sessionLogManager;
-	private final LoggingManager loggingManager;
-	private final PermissionManager permissionManager;
-	private final ConcurrentHashMap<String, SessionContext> sessions = new ConcurrentHashMap<>();
-	private final Set<CallContext> contexts = Collections.synchronizedSet(new LinkedHashSet<CallContext>());
-
-	private final ProfilingManager profiler;
-
-	private Celesta(AppSettings appSettings, boolean initInterpeterPool) throws CelestaException {
-
-		this.appSettings = appSettings;
-		// CELESTA STARTUP SEQUENCE
-		// 1. Разбор описания гранул.
-		System.out.print("Celesta initialization: phase 1/4 score parsing...");
-
-		try {
-			this.score = new Score.ScoreBuilder<>(Score.class)
-					.path(appSettings.getScorePath())
-					.scoreDiscovery(new PyScoreDiscovery())
-					.build();
-		} catch (ParseException e) {
-			throw new CelestaException(e);
-		}
-		CurrentScore.set(this.score);
-		System.out.println("done.");
-
-		// 2. Перекомпиляция ORM-модулей, где это необходимо.
-		System.out.print("Celesta initialization: phase 2/4 data access classes compiling...");
-		ORMCompiler.compile(score);
-		System.out.println("done.");
-
-		// 3. Обновление структуры базы данных.
-		// Т. к. на данном этапе уже используется метаинформация, то theCelesta и ConnectionPool
-		// необходимо проинициализировать.
-
-		ConnectionPoolConfiguration cpc = new ConnectionPoolConfiguration();
-		cpc.setJdbcConnectionUrl(appSettings.getDatabaseConnection());
-		cpc.setDriverClassName(appSettings.getDbClassName());
-		cpc.setLogin(appSettings.getDBLogin());
-		cpc.setPassword(appSettings.getDBPassword());
-		connectionPool = ConnectionPool.create(cpc);
-
-		DbAdaptorFactory dac = new DbAdaptorFactory()
-				.setDbType(appSettings.getDBType())
-				.setDdlConsumer(new JdbcDdlConsumer())
-				.setConnectionPool(connectionPool)
-				.setH2ReferentialIntegrity(appSettings.isH2ReferentialIntegrity());
-
-		dbAdaptor = dac.createDbAdaptor();
-
-		this.sessionLogManager = appSettings.getLogLogins()
-				? Optional.of(new SessionLogManager(this, appSettings.getLogLogins()))
-				: Optional.empty();
-		this.loggingManager = new LoggingManager(dbAdaptor);
-		this.permissionManager = new PermissionManager(dbAdaptor);
-		this.profiler = new ProfilingManager(dbAdaptor);
-
-		if (!appSettings.getSkipDBUpdate()) {
-			System.out.print("Celesta initialization: phase 3/4 database upgrade...");
-
-			DbUpdaterImpl dbUpdater = new DbUpdaterBuilder()
-					.dbAdaptor(dbAdaptor)
-					.connectionPool(connectionPool)
-					.score(score)
-					.forceDdInitialize(appSettings.getForceDBInitialize())
-					.setPermissionManager(permissionManager)
-					.setLoggingManager(loggingManager)
-					.build();
-
-			dbUpdater.updateDb();
-			System.out.println("done.");
-		} else {
-			System.out.println("Celesta initialization: phase 3/4 database upgrade...skipped.");
-		}
-
-		if (initInterpeterPool) {
-			System.out.print("Celesta initialization: phase 4/4 Jython interpreters pool initialization...");
-
-			InterpreterPoolConfiguration ipc = new InterpreterPoolConfiguration()
-					.setCelesta(this)
-					.setScore(score)
-					.setJavaLibPath(appSettings.getJavalibPath())
-					.setScriptLibPath(appSettings.getPylibPath());
-			interpreterPool = InterpreterPoolFactory.create(ipc);
-
-			System.out.println("done.");
-		} else {
-			interpreterPool = null;
-			System.out.println("Celesta initialization: phase 4/4 Jython interpreters pool initialization...skipped.");
-		}
-	}
-
-	/**
-	 * Метод для запуска Celesta из командной строки (для выполнения
-	 * перекомпиляции и обновления базы данных).
-	 * 
-	 * @param args
-	 *            аргументы командной строки.
-	 */
-	public static void main(String[] args) {
-		System.out.println();
-		Celesta celesta = null;
-		try {
-			Properties properties = loadPropertiesDynamically();
-			celesta = createInstance(properties);
-		} catch (CelestaException e) {
-			System.out.println("The following problems occured during initialization process:");
-			System.out.println(e.getMessage());
-			System.exit(1);
-		}
-		System.out.println("Celesta initialized successfully.");
-
-		if (args.length > 1)
-			try {
-				Object[] params = new String[args.length - 2];
-				for (int i = 2; i < args.length; i++)
-					params[i - 2] = args[i];
-
-				String userId = args[0];
-				String sesId = String.format("TEMP%08X", (new Random()).nextInt());
-				// getInstance().setProfilemode(true);
-				celesta.login(sesId, userId);
-				celesta.runPython(sesId, args[1], params);
-				celesta.logout(sesId, false);
-				celesta.interpreterPool.cancelSourceMonitor();
-			} catch (CelestaException e) {
-				System.out.println("The following problems occured while trying to execute " + args[1] + ":");
-				System.out.println(e.getMessage());
-			}
-	}
-
-	/**
-	 * Returns the set of active (running) call contexts (for monitoring/debug
-	 * purposes).
-	 */
-	public Collection<CallContext> getActiveContexts() {
-		return Collections.unmodifiableCollection(contexts);
-	}
-
-	/**
-	 * Связывает идентификатор сессии и идентификатор пользователя.
-	 * 
-	 * @param sessionId
-	 *            Имя сессии.
-	 * @param userId
-	 *            Имя пользователя.
-	 */
-	public void login(String sessionId, String userId) {
-		if (sessionId == null)
-			throw new IllegalArgumentException("Session id is null.");
-		if (userId == null)
-			throw new IllegalArgumentException("User id is null.");
-		// Создавать новый SessionContext имеет смысл лишь в случае, когда
-		// нет старого.
-		SessionContext oldSession = sessions.get(sessionId);
-		if (oldSession == null || !userId.equals(oldSession.getUserId())) {
-			SessionContext session = new SessionContext(userId, sessionId);
-			sessions.put(sessionId, session);
-
-			sessionLogManager.ifPresent(s -> s.logLogin(session));
-		}
-	}
-
-	/**
-	 * Фиксирует (при наличии включённой настройки log.logins) неудачный логин.
-	 * 
-	 * @param userId
-	 *            Имя пользователя, под которым производился вход.
-	 */
-	public void failedLogin(String userId) {
-		sessionLogManager.ifPresent(s -> s.logFailedLogin(userId));
-	}
-
-	/**
-	 * Завершает сессию (удаляет связанные с ней данные).
-	 * 
-	 * @param sessionId
-	 *            имя сессии.
-	 * @param timeout
-	 *            признак разлогинивания по таймауту.
-	 * @throws CelestaException
-	 *             Ошибка взаимодействия с БД.
-	 * 
-	 */
-	public void logout(String sessionId, boolean timeout) {
-		SessionContext sc = sessions.remove(sessionId);
-		if (sc != null) {
-			// Очищаем сессионные данные, дабы облегчить работу сборщика мусора.
-			sc.getData().clear();
-			sessionLogManager.ifPresent(s -> s.logLogout(sc, timeout));
-		}
-	}
-
-	/**
-	 * Запуск питоновской процедуры.
-	 * 
-	 * @param sesId
-	 *            идентификатор пользователя, от имени которого производится
-	 *            изменение
-	 * @param proc
-	 *            Имя процедуры в формате <grain>.<module>.<proc>
-	 * @param param
-	 *            Параметры для передачи процедуры.
-	 * @return PyObject
-	 * @throws CelestaException
-	 *             В случае, если процедура не найдена или в случае ошибки
-	 *             выполненения процедуры.
-	 */
-	public PyObject runPython(String sesId, String proc, Object... param) throws CelestaException {
-		return runPython(sesId, null, null, proc, param);
-	}
-
-	/**
-	 * Запуск питоновской процедуры.
-	 * 
-	 * @param sesId
-	 *            идентификатор пользователя, от имени которого производится
-	 *            изменение
-	 * @param rec
-	 *            приёмник сообщений.
-	 * @param sc
-	 *            Контекст Showcase.
-	 * @param proc
-	 *            Имя процедуры в формате <grain>.<module>.<proc>
-	 * @param param
-	 *            Параметры для передачи процедуры.
-	 * @return PyObject Результат вызова питон-процедуры.
-	 * @throws CelestaException
-	 *             В случае, если процедура не найдена или в случае ошибки
-	 *             выполненения процедуры.
-	 */
-	public PyObject runPython(String sesId, CelestaMessage.MessageReceiver rec, ShowcaseContext sc, String proc,
-			Object... param) throws CelestaException {
-		if (interpreterPool == null)
-			throw new CelestaException("Interperter pool not initialized. Running in debug mode?");
-
-		Matcher m = PROCNAME.matcher(proc);
-
-		if (m.matches()) {
-			String grainName = m.group(1);
-			String unitName = m.group(2);
-			String procName = m.group(4);
-
-			Grain grain;
-			try {
-				grain = getScore().getGrain(grainName);
-			} catch (ParseException e) {
-				throw new CelestaException("Invalid procedure name: %s, grain %s is unknown for the system.", proc,
-						grainName);
-			}
-
-			StringBuilder sb = new StringBuilder("context");
-			for (int i = 0; i < param.length; i++)
-				sb.append(String.format(", arg%d", i));
-
-			SessionContext sesContext = sessions.get(sesId);
-			if (sesContext == null)
-				throw new CelestaException("Session ID=%s is not logged in", sesId);
-
-			sesContext.setMessageReceiver(rec);
-
-
-
-			try (PythonInterpreter interp = interpreterPool.getPythonInterpreter();
-					 CallContext context = new CallContextBuilder()
-							 .setCelesta(this)
-							 .setConnectionPool(connectionPool)
-							 .setSesContext(sesContext)
-							 .setShowcaseContext(sc)
-							 .setScore(score)
-							 .setCurGrain(grain)
-							 .setProcName(proc)
-							 .setDbAdaptor(dbAdaptor)
-							 .setPermissionManager(permissionManager)
-							 .setLoggingManager(loggingManager)
-							 .createCallContext()) {
-				contexts.add(context);
-
-				try {
-					interp.set("context", context);
-					for (int i = 0; i < param.length; i++)
-						interp.set(String.format("arg%d", i), param[i]);
-
-					String lastPyCmd = "";
-					try {
-						String line = String.format("import %s%s", grainName, unitName);
-						lastPyCmd = line;
-						interp.exec(line);
-						line = String.format("%s%s.%s(%s)", grainName, unitName, procName, sb.toString());
-						lastPyCmd = line;
-						PyObject pyObj = interp.eval(line);
-						profiler.logCall(context);
-						return pyObj;
-					} catch (PyException e) {
-						String sqlErr = "";
-						try {
-							// Ошибка базы данных!
-							context.rollback();
-						} catch (SQLException e1) {
-							// Если связь с базой развалилась, об этом тоже сообщим
-							// пользователю.
-							sqlErr = ". SQL error:" + e1.getMessage();
-						}
-						StringWriter sw = new StringWriter();
-						e.fillInStackTrace().printStackTrace(new PrintWriter(sw));
-						throw new CelestaException(String.format("Python error while executing '%s': %s:%s%n%s%n%s",
-								lastPyCmd, e.type, e.value, sw.toString(), sqlErr));
-					}
-				} finally {
-					contexts.remove(context);
-				}
-			} finally {
-				sessions.putIfAbsent(sesId, sesContext);
-			}
-
-		} else {
-			throw new CelestaException("Invalid procedure name: %s, should match pattern <grain>.(<module>.)...<proc>, "
-					+ "note that grain name should not contain underscores.", proc);
-		}
-	}
-
-	public Future<PyObject> runPythonAsync(String sesId, String proc, long delay, Object... param) {
-
-		final ScheduledExecutorService scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
-
-		SessionContext sessionContext = sessions.get(sesId);
-
-		Callable<PyObject> callable = () -> {
-			String currentSesId = null;
-			try {
-
-				if (sessions.containsKey(sesId)) {
-					currentSesId = sesId;
-				} else {
-					currentSesId = String.format("TEMP%08X", ThreadLocalRandom.current().nextInt());
-					login(currentSesId, sessionContext.getUserId());
-				}
-
-				return runPython(currentSesId, proc, param);
-			} catch (Exception e) {
-				System.out.println("Exception while executing async task:" + e.getMessage());
-				throw e;
-			} finally {
-				scheduledExecutor.shutdown();
-
-				if (currentSesId != null && sessions.containsKey(currentSesId))
-					logout(currentSesId, false);
-			}
-		};
-
-		return scheduledExecutor.schedule(callable, delay, TimeUnit.MILLISECONDS);
-	}
-
-	private static void initCL() {
-		Set<URL> urlSet = new LinkedHashSet<URL>();
-
-		File lib = new File(getMyPath() + "lib");
-		addLibEntry(lib, urlSet);
-
-		// Construct the class loader itself
-		if (urlSet.size() > 0) {
-			final URL[] array = urlSet.toArray(new URL[urlSet.size()]);
-			ClassLoader classLoader = AccessController.doPrivileged(new PrivilegedAction<URLClassLoader>() {
-				@Override
-				public URLClassLoader run() {
-					return new URLClassLoader(array, Thread.currentThread().getContextClassLoader());
-				}
-			});
-			Thread.currentThread().setContextClassLoader(classLoader);
-		}
-		Properties postProperties = new Properties();
-		postProperties.setProperty("python.packages.directories", "java.ext.dirs,celesta.lib");
-		postProperties.setProperty("python.console.encoding", "UTF-8");
-		PythonInterpreter.initialize(System.getProperties(), postProperties, null);
-		// codecs.setDefaultEncoding("UTF-8");
-	}
-
-	private static void addLibEntry(File lib, Set<URL> urlSet) {
-		if (lib.exists() && lib.isDirectory() && lib.canRead()) {
-			// Construct the "class path" for this class loader
-			String[] filenames = lib.list();
-			for (String filename : filenames) {
-				if (!filename.toLowerCase().endsWith(".jar"))
-					continue;
-				File file = new File(lib, filename);
-				URL url;
-				try {
-					url = file.toURI().toURL();
-					urlSet.add(url);
-				} catch (MalformedURLException e) {
-					// This can't happen
-					e.printStackTrace();
-				}
-			}
-		}
-	}
-
-
-	/**
-	 * Инициализирует и возвращает новый экземпляр Celesta с проиницилизированным интерпретатором скриптового языка.
-	 * Конфигурация извлекается из файла celesta.properties рядом с jar
-	 * @return Celesta
-	 * @throws CelestaException
-	 */
-	public static Celesta createInstance() throws CelestaException {
-		Properties properties = loadPropertiesDynamically();
-		return createInstance(properties);
-	}
-
-
-	/**
-	 * Инициализирует и возвращает новый экземпляр Celesta без проиницилизированного интерпретатора скриптового языка
-	 * Конфигурация извлекается из файла celesta.properties рядом с jar
-	 * Использовать для отладочных целей
-	 * @return Celesta
-	 * @throws CelestaException
-	 */
-	public static Celesta createDebugInstance() throws CelestaException {
-		Properties properties = loadPropertiesDynamically();
-		return createDebugInstance(properties);
-	}
-
-	/**
-	 * Инициализирует и возвращает новый экземпляр Celesta с проиницилизированным интерпретатором скриптового языка
-	 * @param properties настройки
-	 * @return Celesta
-	 * @throws CelestaException
-	 */
-	public static Celesta createInstance(Properties properties) throws CelestaException {
-		AppSettings appSettings = preInit(properties);
-		return new Celesta(appSettings, true);
-	}
-
-	/**
-	 * Инициализирует и возвращает новый экземпляр Celesta без проиницилизированного интерпретатора скриптового языка
-	 * Использовать для отладочных целей
-	 * @param properties настройки
-	 * @return Celesta
-	 * @throws CelestaException
-	 */
-	public static Celesta createDebugInstance(Properties properties) throws CelestaException {
-		AppSettings appSettings = preInit(properties);
-		return new Celesta(appSettings, false);
-	}
-
-	private static AppSettings preInit(Properties properties) throws CelestaException {
-		System.out.print("Celesta pre-initialization: phase 1/2 system settings reading...");
-		AppSettings appSettings = new AppSettings(properties);
-		System.out.println("done.");
-
-		// Инициализация ClassLoader для нужд Jython-интерпретатора
-		System.out.print("Celesta pre-initialization: phase 2/2 Jython initialization...");
-		initCL();
-		System.out.println("done.");
-
-		return appSettings;
-	}
-
-	private static Properties loadPropertiesDynamically() throws CelestaException {
-		// Разбираемся с настроечным файлом: читаем его и превращаем в
-		// Properties.
-		Properties properties = new Properties();
-		try {
-			ClassLoader loader = Thread.currentThread().getContextClassLoader();
-			InputStream in = loader.getResourceAsStream(FILE_PROPERTIES);
-			if (in == null) {
-				String path = getMyPath();
-				File f = new File(path + FILE_PROPERTIES);
-				if (!f.exists())
-					throw new CelestaException(String.format("File %s cannot be found.", f.toString()));
-				in = new FileInputStream(f);
-			}
-			try {
-				properties.load(in);
-			} finally {
-				in.close();
-			}
-		} catch (IOException e) {
-			throw new CelestaException(String.format("IOException while reading settings file: %s", e.getMessage()));
-		}
-
-		return properties;
-	}
-
-	static String getMyPath() {
-
-		final String result;
-
-		String path = Celesta.class.getResource(Celesta.class.getSimpleName() + ".class").getPath();
-		path = path.replace("%20", " ");
-
-		if (path.contains(".jar")) {
-			if (path.startsWith("file:")) {
-				path = path.replace("file:", "");
-			}
-			path = path.substring(0, path.indexOf("jar!"));
-
-			File f = new File(path).getParentFile();
-			result = f.getPath() + File.separator;
-		} else {
-			File f = new File(path).getParentFile();
-			result = f.getParent() + File.separator;
-		}
-
-		return result;
-	}
-
-	/**
-	 * Возвращает метаданные Celesta (описание таблиц).
-	 */
-	public Score getScore() {
-		return score;
-	}
-
-	/**
-	 * Возвращает свойства, с которыми была инициализирована Челеста. Внимание:
-	 * данный объект имеет смысл использовать только на чтение, динамическое
-	 * изменение этих свойств не приводит ни к чему.
-	 */
-	public Properties getSetupProperties() {
-		return appSettings.getSetupProperties();
-	}
-
-	/**
-	 * Режим профилирования (записывается ли в таблицу calllog время вызовов
-	 * процедур).
-	 */
-	public boolean isProfilemode() {
-		return profiler.isProfilemode();
-	}
-
-	/**
-	 * Возвращает поведение NULLS FIRST текущей базы данных.
-	 * 
-	 * @throws CelestaException
-	 *             unknown database
-	 */
-	public boolean nullsFirst() throws CelestaException {
-		return dbAdaptor.nullsFirst();
-	}
-
-	/**
-	 * Устанавливает режим профилирования.
-	 * 
-	 * @param profilemode
-	 *            режим профилирования.
-	 */
-	public void setProfilemode(boolean profilemode) {
-		profiler.setProfilemode(profilemode);
-	}
-
-	public static TriggerDispatcher getTriggerDispatcher() {
-		return Celesta.triggerDispatcher;
-	}
-
-
-	/**
-	 * Инициализирует и возвращает новый CallContext для указанного SessionContext
-	 * @param sessionContext
-	 * @return CallContext
-	 * @throws CelestaException
-	 */
-	public CallContext callContext(SessionContext sessionContext) throws CelestaException {
-		return new CallContextBuilder()
-				.setCelesta(this)
-				.setConnectionPool(connectionPool)
-				.setSesContext(sessionContext)
-				.setScore(score)
-				.setDbAdaptor(dbAdaptor)
-				.setPermissionManager(permissionManager)
-				.setLoggingManager(loggingManager)
-				.createCallContext();
-	}
-
-
-	/**
-	 * Останавливает работу Celesta. После вызова экземпляр Celesta становится непригодным для использования.
-	 */
-	@Override
-	public void close() {
-		connectionPool.close();
-	}
+    private static final String FILE_PROPERTIES = "celesta.properties";
+    private static final Pattern PROCNAME = Pattern
+            .compile("\\s*([A-Za-z][A-Za-z0-9]*)((\\.[A-Za-z_]\\w*)+)\\.([A-Za-z_]\\w*)\\s*");
+
+    private static final TriggerDispatcher triggerDispatcher = new TriggerDispatcher();
+    private final Score score;
+    private final DBAdaptor dbAdaptor;
+    private final AppSettings appSettings;
+    final ConnectionPool connectionPool;
+    private final PythonInterpreterPool interpreterPool;
+    private final Optional<SessionLogManager> sessionLogManager;
+    private final LoggingManager loggingManager;
+    private final PermissionManager permissionManager;
+    private final ConcurrentHashMap<String, SessionContext> sessions = new ConcurrentHashMap<>();
+    private final Set<CallContext> contexts = Collections.synchronizedSet(new LinkedHashSet<CallContext>());
+
+    private final ProfilingManager profiler;
+    private Optional<Server> server;
+
+    private Celesta(AppSettings appSettings, boolean initInterpeterPool) throws CelestaException {
+        this.appSettings = appSettings;
+        manageH2Server();
+
+        // CELESTA STARTUP SEQUENCE
+        // 1. Разбор описания гранул.
+        System.out.print("Celesta initialization: phase 1/4 score parsing...");
+
+        try {
+            this.score = new Score.ScoreBuilder<>(Score.class)
+                    .path(appSettings.getScorePath())
+                    .scoreDiscovery(new PyScoreDiscovery())
+                    .build();
+        } catch (ParseException e) {
+            throw new CelestaException(e);
+        }
+        CurrentScore.set(this.score);
+        System.out.println("done.");
+
+        // 2. Перекомпиляция ORM-модулей, где это необходимо.
+        System.out.print("Celesta initialization: phase 2/4 data access classes compiling...");
+        ORMCompiler.compile(score);
+        System.out.println("done.");
+
+        // 3. Обновление структуры базы данных.
+        // Т. к. на данном этапе уже используется метаинформация, то theCelesta и ConnectionPool
+        // необходимо проинициализировать.
+        ConnectionPoolConfiguration cpc = new ConnectionPoolConfiguration();
+        cpc.setJdbcConnectionUrl(appSettings.getDatabaseConnection());
+        cpc.setDriverClassName(appSettings.getDbClassName());
+        cpc.setLogin(appSettings.getDBLogin());
+        cpc.setPassword(appSettings.getDBPassword());
+        connectionPool = ConnectionPool.create(cpc);
+
+        DbAdaptorFactory dac = new DbAdaptorFactory()
+                .setDbType(appSettings.getDBType())
+                .setDdlConsumer(new JdbcDdlConsumer())
+                .setConnectionPool(connectionPool)
+                .setH2ReferentialIntegrity(appSettings.isH2ReferentialIntegrity());
+
+        dbAdaptor = dac.createDbAdaptor();
+
+        this.sessionLogManager = appSettings.getLogLogins()
+                ? Optional.of(new SessionLogManager(this, appSettings.getLogLogins()))
+                : Optional.empty();
+        this.loggingManager = new LoggingManager(dbAdaptor);
+        this.permissionManager = new PermissionManager(dbAdaptor);
+        this.profiler = new ProfilingManager(dbAdaptor);
+
+        if (!appSettings.getSkipDBUpdate()) {
+            System.out.print("Celesta initialization: phase 3/4 database upgrade...");
+
+            DbUpdaterImpl dbUpdater = new DbUpdaterBuilder()
+                    .dbAdaptor(dbAdaptor)
+                    .connectionPool(connectionPool)
+                    .score(score)
+                    .forceDdInitialize(appSettings.getForceDBInitialize())
+                    .setPermissionManager(permissionManager)
+                    .setLoggingManager(loggingManager)
+                    .build();
+
+            dbUpdater.updateDb();
+            System.out.println("done.");
+        } else {
+            System.out.println("Celesta initialization: phase 3/4 database upgrade...skipped.");
+        }
+
+        if (initInterpeterPool) {
+            System.out.print("Celesta initialization: phase 4/4 Jython interpreters pool initialization...");
+
+            InterpreterPoolConfiguration ipc = new InterpreterPoolConfiguration()
+                    .setCelesta(this)
+                    .setScore(score)
+                    .setJavaLibPath(appSettings.getJavalibPath())
+                    .setScriptLibPath(appSettings.getPylibPath());
+            interpreterPool = InterpreterPoolFactory.create(ipc);
+
+            System.out.println("done.");
+        } else {
+            interpreterPool = null;
+            System.out.println("Celesta initialization: phase 4/4 Jython interpreters pool initialization...skipped.");
+        }
+    }
+
+    private void manageH2Server() throws CelestaException {
+        if (appSettings.getH2Port() > 0) {
+            try {
+                System.out.printf("H2 server starting on port %d...", appSettings.getH2Port());
+                server = Optional.of(Server.createTcpServer(
+                        "-tcpPort",
+                        Integer.toString(appSettings.getH2Port()),
+                        "-tcpAllowOthers").start());
+                System.out.println("done.");
+
+                CurrentScore.global(true);
+            } catch (SQLException e) {
+                throw new CelestaException(e);
+            }
+        } else {
+            server = Optional.empty();
+            CurrentScore.global(false);
+        }
+    }
+
+    /**
+     * Метод для запуска Celesta из командной строки (для выполнения
+     * перекомпиляции и обновления базы данных).
+     *
+     * @param args аргументы командной строки.
+     */
+    public static void main(String[] args) {
+        System.out.println();
+        Celesta celesta = null;
+        try {
+            Properties properties = loadPropertiesDynamically();
+            celesta = createInstance(properties);
+        } catch (CelestaException e) {
+            System.out.println("The following problems occured during initialization process:");
+            System.out.println(e.getMessage());
+            System.exit(1);
+        }
+        System.out.println("Celesta initialized successfully.");
+
+        if (args.length > 1)
+            try {
+                Object[] params = new String[args.length - 2];
+                System.arraycopy(args, 2, params, 0, args.length - 2);
+
+                String userId = args[0];
+                String sesId = String.format("TEMP%08X", (new Random()).nextInt());
+                // getInstance().setProfilemode(true);
+                celesta.login(sesId, userId);
+                celesta.runPython(sesId, args[1], params);
+                celesta.logout(sesId, false);
+                celesta.interpreterPool.cancelSourceMonitor();
+            } catch (CelestaException e) {
+                System.out.println("The following problems occured while trying to execute " + args[1] + ":");
+                System.out.println(e.getMessage());
+            }
+    }
+
+    /**
+     * Returns the set of active (running) call contexts (for monitoring/debug
+     * purposes).
+     */
+    public Collection<CallContext> getActiveContexts() {
+        return Collections.unmodifiableCollection(contexts);
+    }
+
+    /**
+     * Связывает идентификатор сессии и идентификатор пользователя.
+     *
+     * @param sessionId Имя сессии.
+     * @param userId    Имя пользователя.
+     */
+    public void login(String sessionId, String userId) {
+        if (sessionId == null)
+            throw new IllegalArgumentException("Session id is null.");
+        if (userId == null)
+            throw new IllegalArgumentException("User id is null.");
+        // Создавать новый SessionContext имеет смысл лишь в случае, когда
+        // нет старого.
+        SessionContext oldSession = sessions.get(sessionId);
+        if (oldSession == null || !userId.equals(oldSession.getUserId())) {
+            SessionContext session = new SessionContext(userId, sessionId);
+            sessions.put(sessionId, session);
+
+            sessionLogManager.ifPresent(s -> s.logLogin(session));
+        }
+    }
+
+    /**
+     * Фиксирует (при наличии включённой настройки log.logins) неудачный логин.
+     *
+     * @param userId Имя пользователя, под которым производился вход.
+     */
+    public void failedLogin(String userId) {
+        sessionLogManager.ifPresent(s -> s.logFailedLogin(userId));
+    }
+
+    /**
+     * Завершает сессию (удаляет связанные с ней данные).
+     *
+     * @param sessionId имя сессии.
+     * @param timeout   признак разлогинивания по таймауту.
+     */
+    public void logout(String sessionId, boolean timeout) {
+        SessionContext sc = sessions.remove(sessionId);
+        if (sc != null) {
+            // Очищаем сессионные данные, дабы облегчить работу сборщика мусора.
+            sc.getData().clear();
+            sessionLogManager.ifPresent(s -> s.logLogout(sc, timeout));
+        }
+    }
+
+    /**
+     * Запуск питоновской процедуры.
+     *
+     * @param sesId идентификатор пользователя, от имени которого производится
+     *              изменение
+     * @param proc  Имя процедуры в формате <grain>.<module>.<proc>
+     * @param param Параметры для передачи процедуры.
+     * @return PyObject
+     * @throws CelestaException В случае, если процедура не найдена или в случае ошибки
+     *                          выполненения процедуры.
+     */
+    public PyObject runPython(String sesId, String proc, Object... param) throws CelestaException {
+        return runPython(sesId, null, null, proc, param);
+    }
+
+    /**
+     * Запуск питоновской процедуры.
+     *
+     * @param sesId идентификатор пользователя, от имени которого производится
+     *              изменение
+     * @param rec   приёмник сообщений.
+     * @param sc    Контекст Showcase.
+     * @param proc  Имя процедуры в формате <grain>.<module>.<proc>
+     * @param param Параметры для передачи процедуры.
+     * @return PyObject Результат вызова питон-процедуры.
+     * @throws CelestaException В случае, если процедура не найдена или в случае ошибки
+     *                          выполненения процедуры.
+     */
+    public PyObject runPython(String sesId, CelestaMessage.MessageReceiver rec, ShowcaseContext sc, String proc,
+                              Object... param) throws CelestaException {
+        if (interpreterPool == null)
+            throw new CelestaException("Interperter pool not initialized. Running in debug mode?");
+
+        Matcher m = PROCNAME.matcher(proc);
+
+        if (m.matches()) {
+            String grainName = m.group(1);
+            String unitName = m.group(2);
+            String procName = m.group(4);
+
+            Grain grain;
+            try {
+                grain = getScore().getGrain(grainName);
+            } catch (ParseException e) {
+                throw new CelestaException("Invalid procedure name: %s, grain %s is unknown for the system.", proc,
+                        grainName);
+            }
+
+            StringBuilder sb = new StringBuilder("context");
+            for (int i = 0; i < param.length; i++)
+                sb.append(String.format(", arg%d", i));
+
+            SessionContext sesContext = sessions.get(sesId);
+            if (sesContext == null)
+                throw new CelestaException("Session ID=%s is not logged in", sesId);
+
+            sesContext.setMessageReceiver(rec);
+
+
+            try (PythonInterpreter interp = interpreterPool.getPythonInterpreter();
+                 CallContext context = new CallContextBuilder()
+                         .setCelesta(this)
+                         .setConnectionPool(connectionPool)
+                         .setSesContext(sesContext)
+                         .setShowcaseContext(sc)
+                         .setScore(score)
+                         .setCurGrain(grain)
+                         .setProcName(proc)
+                         .setDbAdaptor(dbAdaptor)
+                         .setPermissionManager(permissionManager)
+                         .setLoggingManager(loggingManager)
+                         .createCallContext()) {
+                contexts.add(context);
+
+                try {
+                    interp.set("context", context);
+                    for (int i = 0; i < param.length; i++)
+                        interp.set(String.format("arg%d", i), param[i]);
+
+                    String lastPyCmd = "";
+                    try {
+                        String line = String.format("import %s%s", grainName, unitName);
+                        lastPyCmd = line;
+                        interp.exec(line);
+                        line = String.format("%s%s.%s(%s)", grainName, unitName, procName, sb.toString());
+                        lastPyCmd = line;
+                        PyObject pyObj = interp.eval(line);
+                        profiler.logCall(context);
+                        return pyObj;
+                    } catch (PyException e) {
+                        String sqlErr = "";
+                        try {
+                            // Ошибка базы данных!
+                            context.rollback();
+                        } catch (SQLException e1) {
+                            // Если связь с базой развалилась, об этом тоже сообщим
+                            // пользователю.
+                            sqlErr = ". SQL error:" + e1.getMessage();
+                        }
+                        StringWriter sw = new StringWriter();
+                        e.fillInStackTrace().printStackTrace(new PrintWriter(sw));
+                        throw new CelestaException(String.format("Python error while executing '%s': %s:%s%n%s%n%s",
+                                lastPyCmd, e.type, e.value, sw.toString(), sqlErr));
+                    }
+                } finally {
+                    contexts.remove(context);
+                }
+            } finally {
+                sessions.putIfAbsent(sesId, sesContext);
+            }
+
+        } else {
+            throw new CelestaException("Invalid procedure name: %s, should match pattern <grain>.(<module>.)...<proc>, "
+                    + "note that grain name should not contain underscores.", proc);
+        }
+    }
+
+    public Future<PyObject> runPythonAsync(String sesId, String proc, long delay, Object... param) {
+
+        final ScheduledExecutorService scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
+
+        SessionContext sessionContext = sessions.get(sesId);
+
+        Callable<PyObject> callable = () -> {
+            String currentSesId = null;
+            try {
+
+                if (sessions.containsKey(sesId)) {
+                    currentSesId = sesId;
+                } else {
+                    currentSesId = String.format("TEMP%08X", ThreadLocalRandom.current().nextInt());
+                    login(currentSesId, sessionContext.getUserId());
+                }
+
+                return runPython(currentSesId, proc, param);
+            } catch (Exception e) {
+                System.out.println("Exception while executing async task:" + e.getMessage());
+                throw e;
+            } finally {
+                scheduledExecutor.shutdown();
+
+                if (currentSesId != null && sessions.containsKey(currentSesId))
+                    logout(currentSesId, false);
+            }
+        };
+
+        return scheduledExecutor.schedule(callable, delay, TimeUnit.MILLISECONDS);
+    }
+
+    private static void initCL() {
+        Set<URL> urlSet = new LinkedHashSet<URL>();
+
+        File lib = new File(getMyPath() + "lib");
+        addLibEntry(lib, urlSet);
+
+        // Construct the class loader itself
+        if (urlSet.size() > 0) {
+            final URL[] array = urlSet.toArray(new URL[urlSet.size()]);
+            ClassLoader classLoader = AccessController.doPrivileged(new PrivilegedAction<URLClassLoader>() {
+                @Override
+                public URLClassLoader run() {
+                    return new URLClassLoader(array, Thread.currentThread().getContextClassLoader());
+                }
+            });
+            Thread.currentThread().setContextClassLoader(classLoader);
+        }
+        Properties postProperties = new Properties();
+        postProperties.setProperty("python.packages.directories", "java.ext.dirs,celesta.lib");
+        postProperties.setProperty("python.console.encoding", "UTF-8");
+        PythonInterpreter.initialize(System.getProperties(), postProperties, null);
+        // codecs.setDefaultEncoding("UTF-8");
+    }
+
+    private static void addLibEntry(File lib, Set<URL> urlSet) {
+        if (lib.exists() && lib.isDirectory() && lib.canRead()) {
+            // Construct the "class path" for this class loader
+            String[] filenames = lib.list();
+            for (String filename : filenames) {
+                if (!filename.toLowerCase().endsWith(".jar"))
+                    continue;
+                File file = new File(lib, filename);
+                URL url;
+                try {
+                    url = file.toURI().toURL();
+                    urlSet.add(url);
+                } catch (MalformedURLException e) {
+                    // This can't happen
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
+
+    /**
+     * Инициализирует и возвращает новый экземпляр Celesta с проиницилизированным интерпретатором скриптового языка.
+     * Конфигурация извлекается из файла celesta.properties рядом с jar
+     *
+     * @return Celesta
+     * @throws CelestaException
+     */
+    public static Celesta createInstance() throws CelestaException {
+        Properties properties = loadPropertiesDynamically();
+        return createInstance(properties);
+    }
+
+
+    /**
+     * Инициализирует и возвращает новый экземпляр Celesta без проиницилизированного интерпретатора скриптового языка
+     * Конфигурация извлекается из файла celesta.properties рядом с jar
+     * Использовать для отладочных целей
+     *
+     * @return Celesta
+     * @throws CelestaException
+     */
+    public static Celesta createDebugInstance() throws CelestaException {
+        Properties properties = loadPropertiesDynamically();
+        return createDebugInstance(properties);
+    }
+
+    /**
+     * Инициализирует и возвращает новый экземпляр Celesta с проиницилизированным интерпретатором скриптового языка
+     *
+     * @param properties настройки
+     * @return Celesta
+     * @throws CelestaException
+     */
+    public static Celesta createInstance(Properties properties) throws CelestaException {
+        AppSettings appSettings = preInit(properties);
+        return new Celesta(appSettings, true);
+    }
+
+    /**
+     * Инициализирует и возвращает новый экземпляр Celesta без проиницилизированного интерпретатора скриптового языка
+     * Использовать для отладочных целей
+     *
+     * @param properties настройки
+     * @return Celesta
+     * @throws CelestaException
+     */
+    public static Celesta createDebugInstance(Properties properties) throws CelestaException {
+        AppSettings appSettings = preInit(properties);
+        return new Celesta(appSettings, false);
+    }
+
+    private static AppSettings preInit(Properties properties) throws CelestaException {
+        System.out.print("Celesta pre-initialization: phase 1/2 system settings reading...");
+        AppSettings appSettings = new AppSettings(properties);
+        System.out.println("done.");
+
+        // Инициализация ClassLoader для нужд Jython-интерпретатора
+        System.out.print("Celesta pre-initialization: phase 2/2 Jython initialization...");
+        initCL();
+        System.out.println("done.");
+        return appSettings;
+    }
+
+    private static Properties loadPropertiesDynamically() throws CelestaException {
+        // Разбираемся с настроечным файлом: читаем его и превращаем в
+        // Properties.
+        Properties properties = new Properties();
+        try {
+            ClassLoader loader = Thread.currentThread().getContextClassLoader();
+            InputStream in = loader.getResourceAsStream(FILE_PROPERTIES);
+            if (in == null) {
+                String path = getMyPath();
+                File f = new File(path + FILE_PROPERTIES);
+                if (!f.exists())
+                    throw new CelestaException(String.format("File %s cannot be found.", f.toString()));
+                in = new FileInputStream(f);
+            }
+            try {
+                properties.load(in);
+            } finally {
+                in.close();
+            }
+        } catch (IOException e) {
+            throw new CelestaException(String.format("IOException while reading settings file: %s", e.getMessage()));
+        }
+
+        return properties;
+    }
+
+    static String getMyPath() {
+
+        final String result;
+
+        String path = Celesta.class.getResource(Celesta.class.getSimpleName() + ".class").getPath();
+        path = path.replace("%20", " ");
+
+        if (path.contains(".jar")) {
+            if (path.startsWith("file:")) {
+                path = path.replace("file:", "");
+            }
+            path = path.substring(0, path.indexOf("jar!"));
+
+            File f = new File(path).getParentFile();
+            result = f.getPath() + File.separator;
+        } else {
+            File f = new File(path).getParentFile();
+            result = f.getParent() + File.separator;
+        }
+
+        return result;
+    }
+
+    /**
+     * Возвращает метаданные Celesta (описание таблиц).
+     */
+    public Score getScore() {
+        return score;
+    }
+
+    /**
+     * Возвращает свойства, с которыми была инициализирована Челеста. Внимание:
+     * данный объект имеет смысл использовать только на чтение, динамическое
+     * изменение этих свойств не приводит ни к чему.
+     */
+    public Properties getSetupProperties() {
+        return appSettings.getSetupProperties();
+    }
+
+    /**
+     * Режим профилирования (записывается ли в таблицу calllog время вызовов
+     * процедур).
+     */
+    public boolean isProfilemode() {
+        return profiler.isProfilemode();
+    }
+
+    /**
+     * Возвращает поведение NULLS FIRST текущей базы данных.
+     *
+     * @throws CelestaException unknown database
+     */
+    public boolean nullsFirst() throws CelestaException {
+        return dbAdaptor.nullsFirst();
+    }
+
+    /**
+     * Устанавливает режим профилирования.
+     *
+     * @param profilemode режим профилирования.
+     */
+    public void setProfilemode(boolean profilemode) {
+        profiler.setProfilemode(profilemode);
+    }
+
+    public static TriggerDispatcher getTriggerDispatcher() {
+        return Celesta.triggerDispatcher;
+    }
+
+
+    /**
+     * Инициализирует и возвращает новый CallContext для указанного SessionContext
+     *
+     * @param sessionContext
+     * @return CallContext
+     * @throws CelestaException
+     */
+    public CallContext callContext(SessionContext sessionContext) throws CelestaException {
+        return new CallContextBuilder()
+                .setCelesta(this)
+                .setConnectionPool(connectionPool)
+                .setSesContext(sessionContext)
+                .setScore(score)
+                .setDbAdaptor(dbAdaptor)
+                .setPermissionManager(permissionManager)
+                .setLoggingManager(loggingManager)
+                .createCallContext();
+    }
+
+
+    /**
+     * Останавливает работу Celesta. После вызова экземпляр Celesta становится непригодным для использования.
+     */
+    @Override
+    public void close() {
+        connectionPool.close();
+        server.ifPresent(Server::shutdown);
+    }
 }

--- a/celesta-core/src/main/java/ru/curs/lyra/BasicGridForm.java
+++ b/celesta-core/src/main/java/ru/curs/lyra/BasicGridForm.java
@@ -1,6 +1,5 @@
 package ru.curs.lyra;
 
-import java.sql.Connection;
 import java.util.*;
 
 import ru.curs.celesta.*;

--- a/celesta-sql/src/main/java/ru/curs/celesta/CurrentScore.java
+++ b/celesta-sql/src/main/java/ru/curs/celesta/CurrentScore.java
@@ -4,12 +4,25 @@ import ru.curs.celesta.score.AbstractScore;
 
 public class CurrentScore {
     private static final ThreadLocal<AbstractScore> CURRENT = new ThreadLocal<>();
+    private static AbstractScore global = null;
+    private static boolean globalMode;
 
     public static AbstractScore get() {
-        return CURRENT.get();
+        if (globalMode)
+            return global;
+        else
+            return CURRENT.get();
     }
 
     public static void set(AbstractScore score) {
-        CURRENT.set(score);
+        if (globalMode)
+            global = score;
+        else
+            CURRENT.set(score);
+    }
+
+
+    public static void global(boolean globalMode) {
+        CurrentScore.globalMode = globalMode;
     }
 }

--- a/celesta-sql/src/main/java/ru/curs/celesta/dbutils/h2/AbstractMaterializeViewTrigger.java
+++ b/celesta-sql/src/main/java/ru/curs/celesta/dbutils/h2/AbstractMaterializeViewTrigger.java
@@ -35,10 +35,11 @@ abstract public class AbstractMaterializeViewTrigger implements Trigger {
 
     @Override
     public void init(Connection connection, String schemaName, String triggerName, String tableName,
-                     boolean before, int type) throws SQLException {
+                     boolean before, int type) {
 
         try {
-            Map<String, Grain> grains = CurrentScore.get().getGrains();
+            AbstractScore score = CurrentScore.get();
+            Map<String, Grain> grains = score.getGrains();
             Grain g = grains.get(schemaName);
             t = g.getElement(tableName, Table.class);
 
@@ -91,17 +92,15 @@ abstract public class AbstractMaterializeViewTrigger implements Trigger {
 
 
     void delete(Connection conn, Object[] row) throws SQLException {
-        StringBuilder deleteSqlBuilder = new StringBuilder("DELETE FROM %s WHERE %s");
 
         HashMap<String, Object> groupByColumnValues = getTableRowGroupByColumns(row);
 
-        String deleteSql = String.format(deleteSqlBuilder.toString(), mvFullName, keySearchTerm);
+        String deleteSql = String.format("DELETE FROM %s WHERE %s", mvFullName, keySearchTerm);
 
         setParamsAndRun(conn, groupByColumnValues, deleteSql);
     }
 
     void insert(Connection conn, Object[] row) throws SQLException {
-        StringBuilder insertSqlBuilder = new StringBuilder("INSERT INTO %s (%s) %s");
 
         HashMap<String, Object> groupByColumnValues = getTableRowGroupByColumns(row);
 
@@ -153,7 +152,7 @@ abstract public class AbstractMaterializeViewTrigger implements Trigger {
         selectStmtBuilder.append(" WHERE ").append(whereCondition)
                 .append(mv.getGroupByPartOfScript());
 
-        String insertSql = String.format(insertSqlBuilder.toString(), mvFullName,
+        String insertSql = String.format("INSERT INTO %s (%s) %s", mvFullName,
                 mvAllColumns + ", \"" + MaterializedView.SURROGATE_COUNT + "\"", selectStmtBuilder.toString());
 
 
@@ -171,11 +170,13 @@ abstract public class AbstractMaterializeViewTrigger implements Trigger {
     }
 
     @Override
-    public void close() throws SQLException {
+    public void close() {
+        //nothing to do
     }
 
     @Override
-    public void remove() throws SQLException {
+    public void remove() {
+        //nothing to do
     }
 
     abstract String getNamePrefix();

--- a/celesta-test/src/test/java/ru/curs/celesta/H2MixedModeTest.java
+++ b/celesta-test/src/test/java/ru/curs/celesta/H2MixedModeTest.java
@@ -1,7 +1,5 @@
 package ru.curs.celesta;
 
-import org.h2.tools.Server;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.sql.*;
@@ -44,7 +42,7 @@ class H2MixedModeTest {
         ) {
             Statement stmt = conn.createStatement();
             ResultSet rs = stmt.executeQuery("select count(*) from \"celesta\".\"grains\"");
-            rs.next();
+            assertTrue(rs.next());
             assertTrue(rs.getInt(1) > 0);
         }
     }

--- a/celesta-test/src/test/java/ru/curs/celesta/H2MixedModeTest.java
+++ b/celesta-test/src/test/java/ru/curs/celesta/H2MixedModeTest.java
@@ -6,6 +6,7 @@ import java.sql.*;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class H2MixedModeTest {
@@ -29,6 +30,9 @@ class H2MixedModeTest {
         assertEquals(Integer.parseInt(port), as.getH2Port());
         assertEquals(jdbcURL,
                 as.getDatabaseConnection());
+
+        params.setProperty("h2.port", "notanumber");
+        assertThrows(CelestaException.class, () -> new AppSettings(params));
     }
 
     @Test

--- a/celesta-test/src/test/java/ru/curs/celesta/H2MixedModeTest.java
+++ b/celesta-test/src/test/java/ru/curs/celesta/H2MixedModeTest.java
@@ -1,0 +1,51 @@
+package ru.curs.celesta;
+
+import org.h2.tools.Server;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.*;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class H2MixedModeTest {
+
+    private final String port = "6557";
+    private final String jdbcURL = String.format(
+            "jdbc:h2:tcp://localhost:%s/mem:celesta", port);
+
+    @Test
+    void h2InMemorySetupPropertyIsParsed() throws CelestaException {
+        Properties params = new Properties();
+        params.setProperty("score.path", "score");
+        params.setProperty("h2.in-memory", "true");
+        AppSettings as = new AppSettings(params);
+        //embedded mode
+        assertEquals("jdbc:h2:mem:celesta;DB_CLOSE_DELAY=-1", as.getDatabaseConnection());
+
+        //mixed mode
+        params.setProperty("h2.port", port);
+        as = new AppSettings(params);
+        assertEquals(Integer.parseInt(port), as.getH2Port());
+        assertEquals(jdbcURL,
+                as.getDatabaseConnection());
+    }
+
+    @Test
+    void celestaRunsInMixedModeOnTcpPort() throws CelestaException, SQLException {
+        Properties params = new Properties();
+        params.setProperty("score.path", "score");
+        params.setProperty("h2.in-memory", "true");
+        params.setProperty("h2.port", port);
+        try (Celesta ignored = Celesta.createInstance(params);
+             Connection conn = DriverManager.getConnection(jdbcURL)
+        ) {
+            Statement stmt = conn.createStatement();
+            ResultSet rs = stmt.executeQuery("select count(*) from \"celesta\".\"grains\"");
+            rs.next();
+            assertTrue(rs.getInt(1) > 0);
+        }
+    }
+}

--- a/celesta-test/src/test/java/ru/curs/celesta/InitTest.java
+++ b/celesta-test/src/test/java/ru/curs/celesta/InitTest.java
@@ -1,113 +1,98 @@
 package ru.curs.celesta;
 
-import java.io.IOException;
-import java.sql.SQLException;
-import java.util.Properties;
-
-
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import ru.curs.celesta.dbutils.BasicCursor;
-import ru.curs.celesta.syscursors.CallLogCursor;
-import ru.curs.celesta.syscursors.GrainsCursor;
-import ru.curs.celesta.syscursors.LogCursor;
-import ru.curs.celesta.syscursors.PermissionsCursor;
-import ru.curs.celesta.syscursors.RolesCursor;
+import ru.curs.celesta.syscursors.*;
+
+import java.sql.SQLException;
+import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class InitTest {
 
-	private static Celesta celesta;
+    private static Celesta celesta;
 
-	@BeforeAll
-	public static void init() throws IOException, CelestaException {
-		Properties params = new Properties();
-		params.setProperty("score.path", "score");
-		params.setProperty("h2.in-memory", "true");
+    @BeforeAll
+    public static void init() throws CelestaException {
+        Properties params = new Properties();
+        params.setProperty("score.path", "score");
+        params.setProperty("h2.in-memory", "true");
+        celesta = Celesta.createInstance(params);
 
-		celesta = Celesta.createInstance(params);
-	}
+        assertSame(celesta.getSetupProperties(), params);
+    }
 
-	@AfterAll
-	public static void destroy() throws CelestaException, SQLException {
-		celesta.connectionPool.get().createStatement().execute("SHUTDOWN");
-		celesta.close();
-	}
+    @AfterAll
+    public static void destroy() throws CelestaException, SQLException {
+        celesta.connectionPool.get().createStatement().execute("SHUTDOWN");
+        celesta.close();
+    }
 
-	@Test
-	public void testGetInstance() throws CelestaException {
-		assertNotNull(celesta);
-	}
+    @Test
+    public void testGetInstance() throws CelestaException {
+        assertNotNull(celesta);
+    }
 
-	@Test
-	public void grainCusrorIsCallable() throws CelestaException {
-		SessionContext sc = new SessionContext("user", "S");
-		try (CallContext ctxt = celesta.callContext(sc)) {
-			GrainsCursor g = new GrainsCursor(ctxt);
-			assertEquals("grains", g.meta().getName());
-			assertEquals(8, g.getMaxStrLen("checksum"));
-			assertEquals(30, g.getMaxStrLen("id"));
-			assertEquals(-1, g.getMaxStrLen("message"));
-			g.reset();
-			g.init();
-			g.clear();
+    @Test
+    public void grainCusrorIsCallable() throws CelestaException {
+        SessionContext sc = new SessionContext("user", "S");
+        try (CallContext ctxt = celesta.callContext(sc)) {
+            GrainsCursor g = new GrainsCursor(ctxt);
+            assertEquals("grains", g.meta().getName());
+            assertEquals(8, g.getMaxStrLen("checksum"));
+            assertEquals(30, g.getMaxStrLen("id"));
+            assertEquals(-1, g.getMaxStrLen("message"));
+            g.reset();
+            g.init();
+            g.clear();
 
-			g.close();
-		}
-	}
+            g.close();
+        }
+    }
 
-	@Test
-	public void logCursorIsCallable() throws CelestaException {
-		SessionContext sc = new SessionContext("user", "S");
-		try (CallContext ctxt = celesta.callContext(sc)) {
-			LogCursor l = new LogCursor(ctxt);
-			assertEquals("log", l.meta().getName());
-			l.orderBy("userid ASC", "pkvalue3 DESC", "pkvalue2");
-			boolean itWas = false;
-			// Неизвестная колонка
-			try {
-				l.orderBy("userid", "psekvalue3 ASC", "pkvsealue3");
-			} catch (CelestaException e) {
-				itWas = true;
-			}
-			assertTrue(itWas);
+    @Test
+    public void logCursorIsCallable() throws CelestaException {
+        SessionContext sc = new SessionContext("user", "S");
+        try (CallContext ctxt = celesta.callContext(sc)) {
+            LogCursor l = new LogCursor(ctxt);
+            assertEquals("log", l.meta().getName());
+            l.orderBy("userid ASC", "pkvalue3 DESC", "pkvalue2");
+            boolean itWas = false;
+            assertAll(
+                    // Неизвестная колонка
+                    () -> assertThrows(CelestaException.class,
+                            () -> l.orderBy("userid", "psekvalue3 ASC", "pkvsealue3")),
+                    // Повтор колонок
+                    () -> assertThrows(CelestaException.class,
+                            () -> l.orderBy("userid ASC", "pkvalue3 ASC", "pkvalue3 DESC")),
+                    // Пустой orderBy
+                    () -> l.orderBy()
+            );
+        }
+    }
 
-			// Повтор колонок
-			itWas = false;
-			try {
-				l.orderBy("userid ASC", "pkvalue3 ASC", "pkvalue3 DESC");
-			} catch (CelestaException e) {
-				itWas = true;
-			}
-			assertTrue(itWas);
+    @Test
+    public void cursorsAreClosingOnContext() throws CelestaException {
+        SessionContext sc = new SessionContext("user", "S");
+        try (CallContext ctxt = celesta.callContext(sc)) {
+            BasicCursor a = new LogCursor(ctxt);
+            BasicCursor b = new PermissionsCursor(ctxt);
+            BasicCursor c = new RolesCursor(ctxt);
+            BasicCursor d = new CallLogCursor(ctxt);
+            assertFalse(a.isClosed());
+            assertFalse(b.isClosed());
+            assertFalse(c.isClosed());
+            assertFalse(d.isClosed());
 
-			// Пустой orderBy
-			l.orderBy();
+            ctxt.close();
 
-		}
-	}
-
-	@Test
-	public void cursorsAreClosingOnContext() throws CelestaException {
-		SessionContext sc = new SessionContext("user", "S");
-		try (CallContext ctxt = celesta.callContext(sc)) {
-			BasicCursor a = new LogCursor(ctxt);
-			BasicCursor b = new PermissionsCursor(ctxt);
-			BasicCursor c = new RolesCursor(ctxt);
-			BasicCursor d = new CallLogCursor(ctxt);
-			assertFalse(a.isClosed());
-			assertFalse(b.isClosed());
-			assertFalse(c.isClosed());
-			assertFalse(d.isClosed());
-
-			ctxt.close();
-
-			assertTrue(a.isClosed());
-			assertTrue(b.isClosed());
-			assertTrue(c.isClosed());
-			assertTrue(d.isClosed());
-		}
-	}
+            assertTrue(a.isClosed());
+            assertTrue(b.isClosed());
+            assertTrue(c.isClosed());
+            assertTrue(d.isClosed());
+        }
+    }
 }

--- a/celesta-test/src/test/java/ru/curs/celesta/InitTest.java
+++ b/celesta-test/src/test/java/ru/curs/celesta/InitTest.java
@@ -60,7 +60,6 @@ public class InitTest {
             LogCursor l = new LogCursor(ctxt);
             assertEquals("log", l.meta().getName());
             l.orderBy("userid ASC", "pkvalue3 DESC", "pkvalue2");
-            boolean itWas = false;
             assertAll(
                     // Неизвестная колонка
                     () -> assertThrows(CelestaException.class,


### PR DESCRIPTION
#### What's done?

Added new initialization parameter: `h2.port`. When this parameter is set together with `h2.in-memory`, Celesta starts with embedded H2 server running in [mixed mode](http://www.h2database.com/html/features.html). 

#### Why is it needed?

For using H2 not only for unit tests, but also for UI/acceptance tests. In these cases we still need to pre-load test database with test data, but test runner may work on another machine / in another JVM. Running H2 in server mode on a certain port makes H2 available for test runners.

#### CurrentScore class became even worse
When H2 runs in server mode, trigger initialization occurs in separate thread, not the main Celesta thread. That is why `ThreadLocal<AbstractScore>` contains `null` when trigger is initialized. This is why when H2 works in server mode `CurrentScore` holds a global value. Disgusting. But do we have any choice?