### PR TITLE
jgitflow-maven-plugin downgraded to 1.0-m4.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <!--plugin versions -->
         <spotbugs.maven.plugin.version>3.1.3</spotbugs.maven.plugin.version>
         <javacc.maven.plugin.version>2.6</javacc.maven.plugin.version>
-        <jgitflow.maven.plugin.version>1.0-m5.1</jgitflow.maven.plugin.version>
+        <jgitflow.maven.plugin.version>1.0-m4.3</jgitflow.maven.plugin.version>
         <maven.assembly.plugin.version>3.1.0</maven.assembly.plugin.version>
         <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
         <maven.compiler.plugin.version>3.3</maven.compiler.plugin.version>


### PR DESCRIPTION
in accordance with [https://ecosystem.atlassian.net/browse/MJF-249](https://ecosystem.atlassian.net/browse/MJF-249)