### PR TITLE
removed unnecessary static checks

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -138,7 +138,6 @@
 
         <!-- Checks for common coding problems               -->
         <!-- See http://checkstyle.sf.net/config_coding.html -->
-        <module name="AvoidInlineConditionals"/>
         <module name="EmptyStatement"/>
         <module name="EqualsHashCode"/>
         <module name="HiddenField">

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter
+    xmlns="https://github.com/spotbugs/filter/3.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+    <Match>
+        <Class name="ru.curs.celesta.score.CelestaParser" />
+    </Match>
+    <Match>
+        <Class name="ru.curs.celesta.score.CelestaParserTokenManager" />
+    </Match>
+    <Match>
+        <Class name="ru.curs.celesta.dbutils.filter.FilterParser" />
+    </Match>
+    <Match>
+        <Class name="ru.curs.celesta.dbutils.filter.FilterParserTokenManager" />
+    </Match>
+</FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -334,6 +334,9 @@
                     <plugin>
                         <groupId>com.github.spotbugs</groupId>
                         <artifactId>spotbugs-maven-plugin</artifactId>
+                        <configuration>
+                            <excludeFilterFile>findbugs-exclude.xml</excludeFilterFile>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>check</id>


### PR DESCRIPTION
1. -AvoidInlineConditionals (we use them anyway)
2. spotbugs now ignores generated parser sources