### PR TITLE
pulled up autocloseable interface

### DIFF
--- a/celesta-core/src/main/java/ru/curs/celesta/ICelesta.java
+++ b/celesta-core/src/main/java/ru/curs/celesta/ICelesta.java
@@ -12,7 +12,7 @@ import java.util.Properties;
 /**
  * Interface of Celesta instance.
  */
-public interface ICelesta {
+public interface ICelesta extends AutoCloseable {
 
     /**
      * Returns a {@link TriggerDispatcher} of this celesta instance.

--- a/celesta-system-services/src/main/java/ru/curs/celesta/Celesta.java
+++ b/celesta-system-services/src/main/java/ru/curs/celesta/Celesta.java
@@ -16,7 +16,7 @@ import java.io.InputStream;
 import java.sql.SQLException;
 import java.util.*;
 
-public class Celesta implements ICelesta, AutoCloseable {
+public class Celesta implements ICelesta {
 
     protected static final String FILE_PROPERTIES = "celesta.properties";
 

--- a/celesta-test/src/test/java/ru/curs/celesta/mock/CelestaImpl.java
+++ b/celesta-test/src/test/java/ru/curs/celesta/mock/CelestaImpl.java
@@ -69,6 +69,7 @@ public class CelestaImpl implements ICelesta {
         return dbAdaptor;
     }
 
+    @Override
     public void close() throws Exception {
         connectionPool.close();
     }


### PR DESCRIPTION
When referencing `ICelesta` instead of `Celesta` there is no reason why `close` method should not be availiable!!