### PR TITLE
More robust behaviour of CallContext

### DIFF
--- a/celesta-core/src/main/java/ru/curs/celesta/CallContext.java
+++ b/celesta-core/src/main/java/ru/curs/celesta/CallContext.java
@@ -43,12 +43,18 @@ public class CallContext implements ICallContext {
     private int dbPid;
     private Date startTime;
     private long startMonotonicTime;
+    private long endMonotonicTime;
 
     private BasicDataAccessor lastDataAccessor;
 
     private int dataAccessorsCount;
     private State state;
 
+    /**
+     * Creates new not activated context.
+     *
+     * @param userId User identifier. Cannot be null or empty.
+     */
     public CallContext(String userId) {
         if (Objects.requireNonNull(userId).isEmpty()) {
             throw new CelestaException("Call context's user Id must not be empty");
@@ -57,6 +63,13 @@ public class CallContext implements ICallContext {
         state = State.NEW;
     }
 
+    /**
+     * Creates activated context.
+     *
+     * @param userId   User identifier. Cannot be null or empty.
+     * @param celesta  Celesta instance.
+     * @param procName Procedure which is being called in this context.
+     */
     public CallContext(String userId, ICelesta celesta, String procName) {
         this(userId);
         activate(celesta, procName);
@@ -68,7 +81,8 @@ public class CallContext implements ICallContext {
 
     /**
      * Activates CallContext with 'live' Celesta and procName.
-     * @param celesta Celesta to use CallContext with.
+     *
+     * @param celesta  Celesta to use CallContext with.
      * @param procName Name of the called procedure (for logging/audit needs).
      */
     public void activate(ICelesta celesta, String procName) {
@@ -78,10 +92,9 @@ public class CallContext implements ICallContext {
         if (state != State.NEW) {
             throw new CelestaException("Cannot activate CallContext in %s state (NEW expected).", state);
         }
-
         this.celesta = celesta;
-        this.state = State.ACTIVE;
         this.procName = procName;
+        this.state = State.ACTIVE;
         conn = celesta.getConnectionPool().get();
         dbPid = PIDSCACHE.computeIfAbsent(conn,
                 getDbAdaptor()::getDBPid);
@@ -104,35 +117,47 @@ public class CallContext implements ICallContext {
     }
 
     /**
-     * Commits the current transaction.
+     * Commits the current transaction. Will cause error for not-activated or closed context.
      * <p>
      * Wraps SQLException into CelestaException.
      */
     public void commit() {
-        try {
-            conn.commit();
-        } catch (SQLException e) {
-            throw new CelestaException("Commit unsuccessful: %s", e.getMessage());
+        if (state == State.ACTIVE) {
+            try {
+                conn.commit();
+            } catch (SQLException e) {
+                throw new CelestaException("Commit unsuccessful: %s", e.getMessage());
+            }
+        } else {
+            throw new CelestaException("Not active context cannot be commited");
         }
     }
 
     /**
-     * Rollbacks the current transaction.
+     * Rollbacks the current transaction. Does nothing for not-activated context.
      * <p>
      * Wraps SQLException into CelestaException.
      */
     public void rollback() {
-        try {
-            conn.rollback();
-        } catch (SQLException e) {
-            throw new CelestaException("Rollback unsuccessful: %s", e.getMessage());
+        if (conn != null) {
+            try {
+                conn.rollback();
+            } catch (SQLException e) {
+                throw new CelestaException("Rollback unsuccessful: %s", e.getMessage());
+            }
         }
     }
 
+    /**
+     * Celesta instance. Null for not activated context.
+     */
     public ICelesta getCelesta() {
         return celesta;
     }
 
+    /**
+     * Score of current Celesta instance.
+     */
     public Score getScore() {
         return celesta.getScore();
     }
@@ -198,9 +223,18 @@ public class CallContext implements ICallContext {
      * Returns number of nanoseconds since CallContext activation.
      */
     public long getDurationNs() {
-        return System.nanoTime() - startMonotonicTime;
+        switch (state){
+            case NEW: return 0;
+            case ACTIVE: return System.nanoTime() - startMonotonicTime;
+            default:
+                return endMonotonicTime - startMonotonicTime;
+        }
+
     }
 
+    /**
+     * If this context is closed.
+     */
     public boolean isClosed() {
         return state == State.CLOSED;
     }
@@ -224,7 +258,10 @@ public class CallContext implements ICallContext {
             if (conn != null) {
                 conn.close();
             }
-            celesta.getProfiler().logCall(this);
+            if (celesta != null) {
+                celesta.getProfiler().logCall(this);
+            }
+            endMonotonicTime = System.nanoTime();
             state = State.CLOSED;
         } catch (Exception e) {
             throw new CelestaException("Can't close callContext", e);

--- a/celesta-documentation/src/main/asciidoc/1010_what_is_celesta.adoc
+++ b/celesta-documentation/src/main/asciidoc/1010_what_is_celesta.adoc
@@ -15,7 +15,7 @@ include::_doc_general_attributes.adoc[]
 
 Celesta -- Java-библиотека и легковесный фреймворк, упрощающий работу с реляционной базой данных из сервисов, реализующих бизнес-логику. 
 
-Может быть использована путём подключения внешней зависимости через https://search.maven.org/search?q=a:celesta-parent[Maven Central], также имеет собственный Spring Boot starter.
+Может быть использована путём подключения внешней зависимости через https://search.maven.org/search?q=a:celesta-parent[Maven Central], также имеет собственный https://github.com/CourseOrchestra/spring-boot-starter-celesta[Spring Boot starter].
 
 image::{img}/640px-Duke2-2.png[width=300]
 


### PR DESCRIPTION
While treating a problem with celesta-spring-boot-starter, I found out that CallContext class behaviour needs further detalization.
* We should *always* be able to call `close()` without causing errors, regardless of current state, because we call `close()` in `finally` and try-with resources blocks.
* We should *always* be able to call `rollback()`, because this method is called in exception handlers. When in active mode, we should wrap `SQLException` into CelestaException. However, when not in active mode, we should silently do nothing, since we can handle the exception of CallContext *activation*, and we should not produce more problems at this point.
* We should be able to *commit* only active contexts. Trying to commit closed or new CallContext is always programming error.
