### PR TITLE
New score discovery tweaks

### DIFF
--- a/celesta-maven-plugin/src/main/java/ru/curs/celesta/plugin/maven/AbstractCelestaMojo.java
+++ b/celesta-maven-plugin/src/main/java/ru/curs/celesta/plugin/maven/AbstractCelestaMojo.java
@@ -37,25 +37,21 @@ abstract class AbstractCelestaMojo extends AbstractMojo {
     MavenProject project;
 
     final Collection<ScoreProperties> getScorePaths() {
+        return getPaths(CELESTASQL_DIR, scores);
+    }
+
+    final Collection<ScoreProperties> getTestScorePaths() {
+        return getPaths(CELESTASQL_TEST_DIR, testScores);
+    }
+
+    private Collection<ScoreProperties> getPaths(String celestasqlDir, List<ScoreProperties> scores) {
         List<ScoreProperties> scorePaths = new ArrayList<>();
 
-        File celestaSqlPath = new File(project.getBasedir(), CELESTASQL_DIR);
+        File celestaSqlPath = new File(project.getBasedir(), celestasqlDir);
         if (celestaSqlPath.exists()) {
             scorePaths.add(new ScoreProperties(celestaSqlPath.getAbsolutePath()));
         }
         scorePaths.addAll(scores);
-
-        return scorePaths;
-    }
-
-    final Collection<ScoreProperties> getTestScorePaths() {
-        List<ScoreProperties> scorePaths = new ArrayList<>();
-
-        File celestaSqlPath = new File(project.getBasedir(), CELESTASQL_TEST_DIR);
-        if (celestaSqlPath.exists()) {
-            scorePaths.add(new ScoreProperties(celestaSqlPath.getAbsolutePath()));
-        }
-        scorePaths.addAll(testScores);
 
         return scorePaths;
     }

--- a/celesta-maven-plugin/src/main/java/ru/curs/celesta/plugin/maven/AbstractCelestaMojo.java
+++ b/celesta-maven-plugin/src/main/java/ru/curs/celesta/plugin/maven/AbstractCelestaMojo.java
@@ -44,14 +44,14 @@ abstract class AbstractCelestaMojo extends AbstractMojo {
         return getPaths(CELESTASQL_TEST_DIR, testScores);
     }
 
-    private Collection<ScoreProperties> getPaths(String celestasqlDir, List<ScoreProperties> scores) {
+    private Collection<ScoreProperties> getPaths(String celestasqlDir, List<ScoreProperties> scoresCollection) {
         List<ScoreProperties> scorePaths = new ArrayList<>();
 
         File celestaSqlPath = new File(project.getBasedir(), celestasqlDir);
         if (celestaSqlPath.exists()) {
             scorePaths.add(new ScoreProperties(celestaSqlPath.getAbsolutePath()));
         }
-        scorePaths.addAll(scores);
+        scorePaths.addAll(scoresCollection);
 
         return scorePaths;
     }

--- a/celesta-unit/src/main/java/ru/curs/celestaunit/CelestaUnitExtension.java
+++ b/celesta-unit/src/main/java/ru/curs/celestaunit/CelestaUnitExtension.java
@@ -21,6 +21,8 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
 
@@ -35,13 +37,13 @@ public final class CelestaUnitExtension implements BeforeAllCallback,
     static final String DEFAULT_SCORE;
 
     static {
-        String score = "src/main/celestasql";
-        String testScore = "src/test/celestasql";
-        File f = new File(testScore);
-        if (f.isDirectory() && f.canRead()) {
-            score += File.pathSeparator + testScore;
-        }
-        DEFAULT_SCORE = score;
+        DEFAULT_SCORE = Stream.of("src/main/celestasql", "src/test/celestasql")
+                .filter(
+                        s -> {
+                            File f = new File(s);
+                            return f.isDirectory() && f.canRead();
+                        }
+                ).collect(Collectors.joining(File.pathSeparator));
     }
 
     private final String scorePath;
@@ -179,6 +181,7 @@ public final class CelestaUnitExtension implements BeforeAllCallback,
 
         /**
          * Sets score path.
+         *
          * @param scorePath Score path (maybe relative to project root).
          */
         public Builder withScorePath(String scorePath) {
@@ -188,6 +191,7 @@ public final class CelestaUnitExtension implements BeforeAllCallback,
 
         /**
          * Sets referential integrity.
+         *
          * @param referentialIntegrity Set to false to disable.
          */
         public Builder withReferentialIntegrity(boolean referentialIntegrity) {
@@ -197,6 +201,7 @@ public final class CelestaUnitExtension implements BeforeAllCallback,
 
         /**
          * Sets tables truncation after each test.
+         *
          * @param truncateAfterEach Set to true to truncate each table after each test.
          */
         public Builder withTruncateAfterEach(boolean truncateAfterEach) {

--- a/celesta-unit/src/main/java/ru/curs/celestaunit/CelestaUnitExtension.java
+++ b/celesta-unit/src/main/java/ru/curs/celestaunit/CelestaUnitExtension.java
@@ -34,17 +34,13 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 public final class CelestaUnitExtension implements BeforeAllCallback,
         AfterAllCallback, ParameterResolver, AfterEachCallback {
 
-    static final String DEFAULT_SCORE;
-
-    static {
-        DEFAULT_SCORE = Stream.of("src/main/celestasql", "src/test/celestasql")
+    static final String DEFAULT_SCORE = Stream.of("src/main/celestasql", "src/test/celestasql")
                 .filter(
                         s -> {
                             File f = new File(s);
                             return f.isDirectory() && f.canRead();
                         }
                 ).collect(Collectors.joining(File.pathSeparator));
-    }
 
     private final String scorePath;
     private final boolean referentialIntegrity;


### PR DESCRIPTION
## Overview

1. In `CelestaUnitExtension` adjusted `DEFAULT_SCORE` calculation logic. In case when "src/test/celestasql" folder existed, but  "src/main/celestasql" didn't exist, CelestaUnitExtension caused 'invalid score path entry' errors. 

2. Small refactor: extracted duplicate code from `AbstractCelestaMojo`

---

### Checklist

- [x] Change is covered by automated tests.
- [x] JavaDoc is provided for all new/changed public APIs.
- [x] User Guide is updated.
- [x] CI builds pass.
