### PR TITLE
update sql server driver, remove gson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,13 +56,12 @@
 
         <!--dependency versions -->
         <checkstyle.version>8.26</checkstyle.version>
-        <gson.version>2.8.6</gson.version>
         <slf4j.version>1.7.29</slf4j.version>
         <h2.version>1.4.197</h2.version>
         <javacc.version>7.0.5</javacc.version>
         <jdbc.driver.oracle.version>12.1.2-0-0</jdbc.driver.oracle.version>
         <jdbc.driver.postgres.version>42.2.8</jdbc.driver.postgres.version>
-        <jdbc.driver.sqlserver.version>6.4.0.jre8</jdbc.driver.sqlserver.version>
+        <jdbc.driver.sqlserver.version>7.4.1.jre8</jdbc.driver.sqlserver.version>
         <jdbc.driver.firebird.version>4.0.0-beta-1</jdbc.driver.firebird.version>
         <junit.version>5.5.2</junit.version>
         <junit.platform.version>1.5.2</junit.platform.version>
@@ -97,11 +96,6 @@
                 <groupId>org.json</groupId>
                 <artifactId>json</artifactId>
                 <version>${org.json.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.code.gson</groupId>
-                <artifactId>gson</artifactId>
-                <version>${gson.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.postgresql</groupId>


### PR DESCRIPTION
## Overview

1. GSON is an orphaned dependency, so it is removed. 
2. Due to non-standard naming, SQL Server JDBC driver cannot be updated with dependabot, so it is manually updated 

---

### Checklist

- [NA] Change is covered by automated tests.
- [NA] JavaDoc is provided for all new/changed public APIs.
- [NA] User Guide is updated.
- [X] CI builds pass.
