### PR TITLE
Bugfix: BasicTable.delete() doesn't remove metadata completely

### DIFF
--- a/celesta-sql/src/main/java/ru/curs/celesta/score/Grain.java
+++ b/celesta-sql/src/main/java/ru/curs/celesta/score/Grain.java
@@ -282,6 +282,7 @@ public final class Grain extends NamedElement {
 
         // Удаляется сама таблица
         getElementsHolder(BasicTable.class).remove(table);
+        getElementsHolder(table.getClass()).remove(table);
     }
 
     /**

--- a/celesta-sql/src/test/java/ru/curs/celesta/score/GrainModelTest.java
+++ b/celesta-sql/src/test/java/ru/curs/celesta/score/GrainModelTest.java
@@ -277,18 +277,18 @@ public class GrainModelTest {
 
         assertEquals(1, t2.getForeignKeys().size());
 
-        final  ForeignKey fk7 = new ForeignKey(t2);
+        final ForeignKey fk7 = new ForeignKey(t2);
         fk7.addColumn("idb");
         fk7.addColumn("datecol");
         // Длина подходящая, но тип неподоходящий
         assertThrows(ParseException.class,
-                () ->  fk7.setReferencedTable("", "t4"));
+                () -> fk7.setReferencedTable("", "t4"));
 
 
         assertEquals(1, t2.getForeignKeys().size());
 
         // А теперь всё должно быть ОК!
-        final  ForeignKey  fk8 = new ForeignKey(t2);
+        final ForeignKey fk8 = new ForeignKey(t2);
         fk8.addColumn("idb");
         fk8.addColumn("intcol");
         fk8.setReferencedTable("", "t4");
@@ -309,7 +309,7 @@ public class GrainModelTest {
         fk9.addColumn("idb");
         fk9.addColumn("intcol");
         assertThrows(ParseException.class,
-                ()-> fk9.setReferencedTable("", "t4"));
+                () -> fk9.setReferencedTable("", "t4"));
     }
 
     @Test
@@ -341,20 +341,41 @@ public class GrainModelTest {
         assertSame(FKRule.NO_ACTION, fk.getUpdateRule());
 
         // нельзя использовать SET NULL в Not-nullable колонках
-        assertThrows(ParseException.class, ()->
-            fk.setDeleteRule(FKRule.SET_NULL));
+        assertThrows(ParseException.class, () ->
+                fk.setDeleteRule(FKRule.SET_NULL));
 
         assertSame(FKRule.NO_ACTION, fk.getDeleteRule());
         fk.setDeleteRule(FKRule.CASCADE);
         assertSame(FKRule.CASCADE, fk.getDeleteRule());
 
         // нельзя использовать SET NULL в Not-nullable колонках
-        assertThrows(ParseException.class, ()->
-            fk.setUpdateRule(FKRule.SET_NULL));
+        assertThrows(ParseException.class, () ->
+                fk.setUpdateRule(FKRule.SET_NULL));
 
         assertSame(FKRule.NO_ACTION, fk.getUpdateRule());
         fk.setUpdateRule(FKRule.CASCADE);
         assertSame(FKRule.CASCADE, fk.getUpdateRule());
+    }
+
+    @Test
+    void tableRemovalTest() throws ParseException {
+        Grain gm = new Grain(s, "tableremoval");
+        GrainPart gp = new GrainPart(gm, true, null);
+        BasicTable t1 = new Table(gp, "t1");
+        BasicTable t2 = new ReadOnlyTable(gp, "t2");
+        assertEquals(2, gm.getTables().size());
+        //delete and recreate - no exceptions should be thrown
+        t1.delete();
+        t2.delete();
+        assertEquals(0, gm.getTables().size());
+        t1 = new Table(gp, "t1");
+        t2 = new ReadOnlyTable(gp, "t2");
+        //now swap table classes
+        t1.delete();
+        t2.delete();
+        new ReadOnlyTable(gp, "t1");
+        new Table(gp, "t2");
+        assertEquals(2, gm.getTables().size());
     }
 
     @Test


### PR DESCRIPTION
## Overview

There has been a problem since `Table` class was  split into `BasicTable`/`Table`/`ReadOnlyTable`

Steps to reproduce: 

```java
BasicTable t1 = new Table(gp, "t1");
t1.delete();
new Table(gp, "t1"); //'table already exists' exception
```
---

### Checklist

- [X] Change is covered by automated tests.
- NA JavaDoc / User Guide is updated.
- [x] CI builds pass.
- [x] PR is tagged.
