### PR TITLE
use oracle driver from Maven Central

### DIFF
--- a/celesta-test/pom.xml
+++ b/celesta-test/pom.xml
@@ -65,7 +65,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.oracle.weblogic</groupId>
+            <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc6</artifactId>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <slf4j.version>1.7.30</slf4j.version>
         <h2.version>1.4.200</h2.version>
         <javacc.version>7.0.5</javacc.version>
-        <jdbc.driver.oracle.version>12.1.2-0-0</jdbc.driver.oracle.version>
+        <jdbc.driver.oracle.version>11.2.0.4</jdbc.driver.oracle.version>
         <jdbc.driver.postgres.version>42.2.10</jdbc.driver.postgres.version>
         <jdbc.driver.sqlserver.version>8.2.1.jre8</jdbc.driver.sqlserver.version>
         <jdbc.driver.firebird.version>4.0.0-beta-1</jdbc.driver.firebird.version>
@@ -108,7 +108,7 @@
                 <scope>runtime</scope>
             </dependency>
             <dependency>
-                <groupId>com.oracle.weblogic</groupId>
+                <groupId>com.oracle.database.jdbc</groupId>
                 <artifactId>ojdbc6</artifactId>
                 <version>${jdbc.driver.oracle.version}</version>
                 <scope>runtime</scope>


### PR DESCRIPTION
## Overview

Oracle JDBC drivers [are now on Maven Central 
](https://medium.com/oracledevs/all-in-and-new-groupids-oracle-jdbc-drivers-on-maven-central-a76d545954c6)
---

### Checklist

- [ ] Change is covered by automated tests.
- [ ] JavaDoc / User Guide is updated.
- [x] CI builds pass.
- [x] PR is tagged.
