### PR TITLE
Fixed: wrong foreign keys metadata for Firebird

### DIFF
--- a/celesta-core/pom.xml
+++ b/celesta-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>celesta-parent</artifactId>
         <groupId>ru.curs</groupId>
-        <version>7.2.14-SNAPSHOT</version>
+        <version>7.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-sql</artifactId>
-            <version>7.2.14-SNAPSHOT</version>
+            <version>7.3.0-SNAPSHOT</version>
         </dependency>
 
         <!-- TEST DEPENDENCIES -->

--- a/celesta-documentation/pom.xml
+++ b/celesta-documentation/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>celesta-parent</artifactId>
         <groupId>ru.curs</groupId>
-        <version>7.2.14-SNAPSHOT</version>
+        <version>7.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/celesta-maven-plugin/pom.xml
+++ b/celesta-maven-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>celesta-parent</artifactId>
         <groupId>ru.curs</groupId>
-        <version>7.2.14-SNAPSHOT</version>
+        <version>7.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-core</artifactId>
-            <version>7.2.14-SNAPSHOT</version>
+            <version>7.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.squareup</groupId>

--- a/celesta-sql/pom.xml
+++ b/celesta-sql/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>celesta-parent</artifactId>
         <groupId>ru.curs</groupId>
-        <version>7.2.14-SNAPSHOT</version>
+        <version>7.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/celesta-sql/src/main/java/ru/curs/celesta/dbutils/adaptors/FirebirdAdaptor.java
+++ b/celesta-sql/src/main/java/ru/curs/celesta/dbutils/adaptors/FirebirdAdaptor.java
@@ -555,7 +555,7 @@ public final class FirebirdAdaptor extends DBAdaptor {
                 "WHERE%n" +
                 "    detail_relation_constraints.rdb$constraint_type = 'FOREIGN KEY'%n" +
                 "    AND detail_relation_constraints.rdb$relation_name like '%s@_%%' escape '@'%n" +
-                "ORDER BY constraint_name, column_name, detail_index_segments.rdb$field_position;",
+                "ORDER BY table_name, constraint_name, detail_index_segments.rdb$field_position;",
             g.getName()
         );
 

--- a/celesta-sql/src/main/java/ru/curs/celesta/dbutils/adaptors/FirebirdAdaptor.java
+++ b/celesta-sql/src/main/java/ru/curs/celesta/dbutils/adaptors/FirebirdAdaptor.java
@@ -451,13 +451,13 @@ public final class FirebirdAdaptor extends DBAdaptor {
                 if (IntegerColumn.class.equals(dbColumnInfo.getType())) {
                     String triggerName = SchemalessFunctions.generateSequenceTriggerName((IntegerColumn) c);
                     sql = String.format(
-                            "SELECT proc.RDB$DEPENDED_ON_NAME %n "
-                                    + "FROM RDB$DEPENDENCIES tr%n "
-                                    + "JOIN RDB$DEPENDENCIES proc ON tr.RDB$DEPENDED_ON_NAME = proc.RDB$DEPENDENT_NAME%n "
-                                    + "WHERE tr.RDB$DEPENDENT_NAME = '%s' AND tr.RDB$DEPENDENT_TYPE = 2 "
-                                    + "AND tr.RDB$DEPENDED_ON_TYPE = 5%n "
-                                    + "AND proc.RDB$DEPENDENT_TYPE = 5 AND proc.RDB$DEPENDED_ON_TYPE = 14",
-                            triggerName
+                        "SELECT proc.RDB$DEPENDED_ON_NAME %n "
+                                + "FROM RDB$DEPENDENCIES tr%n "
+                                + "JOIN RDB$DEPENDENCIES proc ON tr.RDB$DEPENDED_ON_NAME = proc.RDB$DEPENDENT_NAME%n "
+                                + "WHERE tr.RDB$DEPENDENT_NAME = '%s' AND tr.RDB$DEPENDENT_TYPE = 2 "
+                                + "AND tr.RDB$DEPENDED_ON_TYPE = 5%n "
+                                + "AND proc.RDB$DEPENDENT_TYPE = 5 AND proc.RDB$DEPENDED_ON_TYPE = 14",
+                        triggerName
                     );
 
                     try (ResultSet sequenceRs = SqlUtils.executeQuery(conn, sql)) {
@@ -538,26 +538,26 @@ public final class FirebirdAdaptor extends DBAdaptor {
     @Override
     public List<DbFkInfo> getFKInfo(Connection conn, Grain g) {
         String sql = String.format(
-                "SELECT"
-                        + "    detail_relation_constraints.RDB$RELATION_NAME as table_name%n"
-                        + "    , detail_relation_constraints.RDB$CONSTRAINT_NAME as constraint_name%n"
-                        + "    , ref_constraints.RDB$UPDATE_RULE as update_rule%n"
-                        + "    , ref_constraints.RDB$DELETE_RULE as delete_rule%n"
-                        + "    , detail_index_segments.rdb$field_name AS column_name%n"
-                        + "    , master_relation_constraints.rdb$relation_name AS ref_table_name%n"
-                        + "FROM%n"
-                        + "    rdb$relation_constraints detail_relation_constraints%n"
-                        + "    JOIN rdb$index_segments detail_index_segments ON "
-                        + "      detail_relation_constraints.rdb$index_name = detail_index_segments.rdb$index_name %n"
-                        + "    JOIN rdb$ref_constraints ref_constraints ON "
-                        + "      detail_relation_constraints.rdb$constraint_name = ref_constraints.rdb$constraint_name%n"
-                        + "    JOIN rdb$relation_constraints master_relation_constraints ON "
-                        + "      ref_constraints.rdb$const_name_uq = master_relation_constraints.rdb$constraint_name%n"
-                        + "WHERE%n"
-                        + "    detail_relation_constraints.rdb$constraint_type = 'FOREIGN KEY'%n"
-                        + "    AND detail_relation_constraints.rdb$relation_name like '%s@_%%' escape '@'%n"
-                        + "ORDER BY table_name, constraint_name, detail_index_segments.rdb$field_position;",
-                g.getName()
+            "SELECT"
+                    + "    detail_relation_constraints.RDB$RELATION_NAME as table_name%n"
+                    + "    , detail_relation_constraints.RDB$CONSTRAINT_NAME as constraint_name%n"
+                    + "    , ref_constraints.RDB$UPDATE_RULE as update_rule%n"
+                    + "    , ref_constraints.RDB$DELETE_RULE as delete_rule%n"
+                    + "    , detail_index_segments.rdb$field_name AS column_name%n"
+                    + "    , master_relation_constraints.rdb$relation_name AS ref_table_name%n"
+                    + "FROM%n"
+                    + "    rdb$relation_constraints detail_relation_constraints%n"
+                    + "    JOIN rdb$index_segments detail_index_segments ON "
+                    + "      detail_relation_constraints.rdb$index_name = detail_index_segments.rdb$index_name %n"
+                    + "    JOIN rdb$ref_constraints ref_constraints ON "
+                    + "      detail_relation_constraints.rdb$constraint_name = ref_constraints.rdb$constraint_name%n"
+                    + "    JOIN rdb$relation_constraints master_relation_constraints ON "
+                    + "      ref_constraints.rdb$const_name_uq = master_relation_constraints.rdb$constraint_name%n"
+                    + "WHERE%n"
+                    + "    detail_relation_constraints.rdb$constraint_type = 'FOREIGN KEY'%n"
+                    + "    AND detail_relation_constraints.rdb$relation_name like '%s@_%%' escape '@'%n"
+                    + "ORDER BY table_name, constraint_name, detail_index_segments.rdb$field_position;",
+            g.getName()
         );
 
         Map<String, DbFkInfo> fks = new HashMap<>();

--- a/celesta-sql/src/main/java/ru/curs/celesta/dbutils/adaptors/FirebirdAdaptor.java
+++ b/celesta-sql/src/main/java/ru/curs/celesta/dbutils/adaptors/FirebirdAdaptor.java
@@ -60,6 +60,7 @@ import static ru.curs.celesta.dbutils.jdbc.SqlUtils.executeUpdate;
 
 /**
  * FirebirdAdaptor.
+ *
  * @author ioanngolovko
  */
 public final class FirebirdAdaptor extends DBAdaptor {
@@ -73,7 +74,7 @@ public final class FirebirdAdaptor extends DBAdaptor {
     private static final Pattern DATE_PATTERN = Pattern.compile("'(\\d\\d)\\.(\\d\\d)\\.(\\d\\d\\d\\d)'");
 
     private static final Pattern SEQUENCE_INFO_PATTERN =
-        Pattern.compile("/\\* INCREMENT_BY = (.*), MINVALUE = (.*), MAXVALUE = (.*), CYCLE = (.*) \\*/");
+            Pattern.compile("/\\* INCREMENT_BY = (.*), MINVALUE = (.*), MAXVALUE = (.*), CYCLE = (.*) \\*/");
 
     private static final String CUR_VALUE_PROC_POSTFIX = "curValueProc";
     private static final String NEXT_VALUE_PROC_POSTFIX = "nextValueProc";
@@ -106,13 +107,13 @@ public final class FirebirdAdaptor extends DBAdaptor {
         final String fieldList = getTableFieldsListExceptBlobs(from.getGe(), fields);
 
         sql = String.format(
-            "SELECT %s SKIP %d %s FROM %s %s ORDER BY %s",
-            firstSql,
-            offset,
-            fieldList,
-            from.getExpression(),
-            sqlwhere,
-            orderBy
+                "SELECT %s SKIP %d %s FROM %s %s ORDER BY %s",
+                firstSql,
+                offset,
+                fieldList,
+                from.getExpression(),
+                sqlwhere,
+                orderBy
         );
 
         return sql;
@@ -123,8 +124,8 @@ public final class FirebirdAdaptor extends DBAdaptor {
     @Override
     String getSelectTriggerBodySql(TriggerQuery query) {
         String sql = String.format("SELECT RDB$TRIGGER_SOURCE FROM RDB$TRIGGERS "
-                + "WHERE RDB$TRIGGER_NAME = '%s' AND RDB$RELATION_NAME = '%s_%s'",
-            query.getName(), query.getSchema(), query.getTableName());
+                        + "WHERE RDB$TRIGGER_NAME = '%s' AND RDB$RELATION_NAME = '%s_%s'",
+                query.getName(), query.getSchema(), query.getTableName());
 
         return sql;
     }
@@ -132,8 +133,8 @@ public final class FirebirdAdaptor extends DBAdaptor {
     @Override
     boolean userTablesExist(Connection conn) throws SQLException {
         String sql = "SELECT COUNT(*) \n"
-            + "FROM RDB$RELATIONS RDB$RELATIONS \n"
-            + "WHERE RDB$SYSTEM_FLAG = 0";
+                + "FROM RDB$RELATIONS RDB$RELATIONS \n"
+                + "WHERE RDB$SYSTEM_FLAG = 0";
 
         try (ResultSet rs = SqlUtils.executeQuery(conn, sql)) {
             rs.next();
@@ -159,8 +160,8 @@ public final class FirebirdAdaptor extends DBAdaptor {
             w.append(" order by " + orderBy);
         }
         String sql = String.format("SELECT FIRST 1 SKIP %d %s FROM  %s %s;", offset == 0 ? 0 : offset - 1,
-            fieldList,
-            from.getExpression(), useWhere ? " where " + w : w);
+                fieldList,
+                from.getExpression(), useWhere ? " where " + w : w);
         LOGGER.trace(sql);
         return prepareStatement(conn, sql);
     }
@@ -168,11 +169,11 @@ public final class FirebirdAdaptor extends DBAdaptor {
     @Override
     public boolean tableExists(Connection conn, String schema, String name) {
         String sql = String.format(
-            "SELECT count(*)%n"
-                + "FROM RDB$RELATIONS%n"
-                + "WHERE RDB$RELATION_NAME = '%s_%s'",
-            schema,
-            name
+                "SELECT count(*)%n"
+                        + "FROM RDB$RELATIONS%n"
+                        + "WHERE RDB$RELATION_NAME = '%s_%s'",
+                schema,
+                name
         );
 
         try (ResultSet rs = SqlUtils.executeQuery(conn, sql)) {
@@ -188,12 +189,12 @@ public final class FirebirdAdaptor extends DBAdaptor {
     @Override
     public boolean triggerExists(Connection conn, TriggerQuery query) throws SQLException {
         String sql = String.format(
-            "SELECT count(*) FROM RDB$TRIGGERS%n"
-                + "WHERE %n"
-                + "  RDB$TRIGGER_NAME = '%s' AND RDB$RELATION_NAME = '%s_%s'",
-            query.getName(),
-            query.getSchema(),
-            query.getTableName()
+                "SELECT count(*) FROM RDB$TRIGGERS%n"
+                        + "WHERE %n"
+                        + "  RDB$TRIGGER_NAME = '%s' AND RDB$RELATION_NAME = '%s_%s'",
+                query.getName(),
+                query.getSchema(),
+                query.getTableName()
         );
 
         try (Statement stmt = conn.createStatement()) {
@@ -228,10 +229,10 @@ public final class FirebirdAdaptor extends DBAdaptor {
     public PreparedStatement getOneRecordStatement(Connection conn, TableElement t, String where, Set<String> fields) {
         final String fieldList = getTableFieldsListExceptBlobs((DataGrainElement) t, fields);
         String sql = String.format(
-            "select first 1 %s from %s where %s;",
-            fieldList,
-            tableString(t.getGrain().getName(), t.getName()),
-            where
+                "select first 1 %s from %s where %s;",
+                fieldList,
+                tableString(t.getGrain().getName(), t.getName()),
+                where
         );
 
         PreparedStatement result = prepareStatement(conn, sql);
@@ -244,10 +245,10 @@ public final class FirebirdAdaptor extends DBAdaptor {
         TableElement t = c.getParentTable();
 
         String sql = String.format(
-            "select first 1 %s from %s where %s;",
-            c.getQuotedName(),
-            tableString(t.getGrain().getName(), t.getName()),
-            where
+                "select first 1 %s from %s where %s;",
+                c.getQuotedName(),
+                tableString(t.getGrain().getName(), t.getName()),
+                where
         );
 
         return prepareStatement(conn, sql);
@@ -258,7 +259,7 @@ public final class FirebirdAdaptor extends DBAdaptor {
         // TODO:: COPY PASTE
         // Готовим запрос на удаление
         String sql = String.format("delete from " + tableString(t.getGrain().getName(), t.getName()) + " %s;",
-            where.isEmpty() ? "" : "where " + where);
+                where.isEmpty() ? "" : "where " + where);
         try {
             return conn.prepareStatement(sql);
         } catch (SQLException e) {
@@ -305,10 +306,10 @@ public final class FirebirdAdaptor extends DBAdaptor {
 
         if (fields.length() == 0 && params.length() == 0) {
             sql = String.format("insert into " + tableString(t.getGrain().getName(),
-                t.getName()) + " default values %s;", returning);
+                    t.getName()) + " default values %s;", returning);
         } else {
             sql = String.format("insert into " + tableString(t.getGrain().getName(),
-                t.getName()) + " (%s) values (%s)%s;", fields.toString(), params.toString(), returning);
+                    t.getName()) + " (%s) values (%s)%s;", fields.toString(), params.toString(), returning);
         }
 
         return prepareStatement(conn, sql);
@@ -318,10 +319,10 @@ public final class FirebirdAdaptor extends DBAdaptor {
     public int getCurrentIdent(Connection conn, BasicTable t) {
 
         IntegerColumn idColumn = t.getPrimaryKey().values().stream()
-            .filter(c -> c instanceof IntegerColumn)
-            .map(c -> (IntegerColumn) c)
-            .filter(ic -> ic.getSequence() != null)
-            .findFirst().get();
+                .filter(c -> c instanceof IntegerColumn)
+                .map(c -> (IntegerColumn) c)
+                .filter(ic -> ic.getSequence() != null)
+                .findFirst().get();
 
         final SequenceElement s = idColumn.getSequence();
         String curValueProcName = sequenceCurValueProcString(s.getGrain().getName(), s.getName());
@@ -339,46 +340,46 @@ public final class FirebirdAdaptor extends DBAdaptor {
     public PreparedStatement getDeleteRecordStatement(Connection conn, TableElement t, String where) {
         // TODO:: COPY PASTE
         String sql = String.format("delete from " + tableString(t.getGrain().getName(), t.getName()) + " where %s;",
-            where);
+                where);
         return prepareStatement(conn, sql);
     }
 
     @Override
     public DbColumnInfo getColumnInfo(Connection conn, Column<?> c) {
         String sql = String.format(
-            "SELECT r.RDB$FIELD_NAME AS column_name,%n"
-                + "        r.RDB$DESCRIPTION AS field_description,%n"
-                + "        r.RDB$NULL_FLAG AS nullable,%n"
-                + "        f.RDB$FIELD_LENGTH AS column_length,%n"
-                + "        f.RDB$FIELD_PRECISION AS column_precision,%n"
-                + "        f.RDB$FIELD_SCALE AS column_scale,%n"
-                + "        CASE f.RDB$FIELD_TYPE%n"
-                + "          WHEN 261 THEN 'BLOB'%n"
-                + "          WHEN 14 THEN 'CHAR'%n"
-                + "          WHEN 40 THEN 'CSTRING'%n"
-                + "          WHEN 11 THEN 'D_FLOAT'%n"
-                + "          WHEN 27 THEN 'DOUBLE PRECISION'%n"
-                + "          WHEN 10 THEN 'FLOAT'%n"
-                + "          WHEN 16 THEN 'BIGINT'%n"
-                + "          WHEN 8 THEN 'INTEGER'%n"
-                + "          WHEN 9 THEN 'QUAD'%n"
-                + "          WHEN 7 THEN 'SMALLINT'%n"
-                + "          WHEN 12 THEN 'DATE'%n"
-                + "          WHEN 13 THEN 'TIME'%n"
-                + "          WHEN 35 THEN 'TIMESTAMP'%n"
-                + "          WHEN 29 THEN 'TIMESTAMP WITH TIME ZONE'%n"
-                + "          WHEN 37 THEN 'VARCHAR'%n"
-                + "          ELSE 'UNKNOWN'%n"
-                + "        END AS column_type,%n"
-                + "        f.RDB$FIELD_SUB_TYPE AS column_subtype%n"
-                + "   FROM RDB$RELATION_FIELDS r%n"
-                + "   LEFT JOIN RDB$FIELDS f ON r.RDB$FIELD_SOURCE = f.RDB$FIELD_NAME%n"
-                + "   LEFT JOIN RDB$COLLATIONS coll ON f.RDB$COLLATION_ID = coll.RDB$COLLATION_ID%n"
-                + "   LEFT JOIN RDB$CHARACTER_SETS cset ON f.RDB$CHARACTER_SET_ID = cset.RDB$CHARACTER_SET_ID%n"
-                + "  WHERE r.RDB$RELATION_NAME='%s_%s' AND r.RDB$FIELD_NAME = '%s'",
-            c.getParentTable().getGrain().getName(),
-            c.getParentTable().getName(),
-            c.getName()
+                "SELECT r.RDB$FIELD_NAME AS column_name,%n"
+                        + "        r.RDB$DESCRIPTION AS field_description,%n"
+                        + "        r.RDB$NULL_FLAG AS nullable,%n"
+                        + "        f.RDB$FIELD_LENGTH AS column_length,%n"
+                        + "        f.RDB$FIELD_PRECISION AS column_precision,%n"
+                        + "        f.RDB$FIELD_SCALE AS column_scale,%n"
+                        + "        CASE f.RDB$FIELD_TYPE%n"
+                        + "          WHEN 261 THEN 'BLOB'%n"
+                        + "          WHEN 14 THEN 'CHAR'%n"
+                        + "          WHEN 40 THEN 'CSTRING'%n"
+                        + "          WHEN 11 THEN 'D_FLOAT'%n"
+                        + "          WHEN 27 THEN 'DOUBLE PRECISION'%n"
+                        + "          WHEN 10 THEN 'FLOAT'%n"
+                        + "          WHEN 16 THEN 'BIGINT'%n"
+                        + "          WHEN 8 THEN 'INTEGER'%n"
+                        + "          WHEN 9 THEN 'QUAD'%n"
+                        + "          WHEN 7 THEN 'SMALLINT'%n"
+                        + "          WHEN 12 THEN 'DATE'%n"
+                        + "          WHEN 13 THEN 'TIME'%n"
+                        + "          WHEN 35 THEN 'TIMESTAMP'%n"
+                        + "          WHEN 29 THEN 'TIMESTAMP WITH TIME ZONE'%n"
+                        + "          WHEN 37 THEN 'VARCHAR'%n"
+                        + "          ELSE 'UNKNOWN'%n"
+                        + "        END AS column_type,%n"
+                        + "        f.RDB$FIELD_SUB_TYPE AS column_subtype%n"
+                        + "   FROM RDB$RELATION_FIELDS r%n"
+                        + "   LEFT JOIN RDB$FIELDS f ON r.RDB$FIELD_SOURCE = f.RDB$FIELD_NAME%n"
+                        + "   LEFT JOIN RDB$COLLATIONS coll ON f.RDB$COLLATION_ID = coll.RDB$COLLATION_ID%n"
+                        + "   LEFT JOIN RDB$CHARACTER_SETS cset ON f.RDB$CHARACTER_SET_ID = cset.RDB$CHARACTER_SET_ID%n"
+                        + "  WHERE r.RDB$RELATION_NAME='%s_%s' AND r.RDB$FIELD_NAME = '%s'",
+                c.getParentTable().getGrain().getName(),
+                c.getParentTable().getName(),
+                c.getName()
         );
 
         try (ResultSet rs = SqlUtils.executeQuery(conn, sql)) {
@@ -390,8 +391,8 @@ public final class FirebirdAdaptor extends DBAdaptor {
                 Integer columnSubType = rs.getInt("column_subtype");
 
                 if (
-                    ("BIGINT".equals(columnType) || "INTEGER".equals(columnType))
-                        && Integer.valueOf(2).equals(columnSubType)
+                        ("BIGINT".equals(columnType) || "INTEGER".equals(columnType))
+                                && Integer.valueOf(2).equals(columnSubType)
                 ) {
                     result.setType(DecimalColumn.class);
                     result.setLength(rs.getInt("column_precision"));
@@ -433,12 +434,12 @@ public final class FirebirdAdaptor extends DBAdaptor {
         Grain g = te.getGrain();
 
         String sql = String.format(
-            "SELECT r.RDB$DEFAULT_SOURCE AS column_default_value%n"
-                + "   FROM RDB$RELATION_FIELDS r%n"
-                + "   WHERE r.RDB$RELATION_NAME='%s_%s' AND r.RDB$FIELD_NAME = '%s'",
-            c.getParentTable().getGrain().getName(),
-            c.getParentTable().getName(),
-            c.getName()
+                "SELECT r.RDB$DEFAULT_SOURCE AS column_default_value%n"
+                        + "   FROM RDB$RELATION_FIELDS r%n"
+                        + "   WHERE r.RDB$RELATION_NAME='%s_%s' AND r.RDB$FIELD_NAME = '%s'",
+                c.getParentTable().getGrain().getName(),
+                c.getParentTable().getName(),
+                c.getName()
         );
 
         try (ResultSet rs = SqlUtils.executeQuery(conn, sql)) {
@@ -450,22 +451,22 @@ public final class FirebirdAdaptor extends DBAdaptor {
                 if (IntegerColumn.class.equals(dbColumnInfo.getType())) {
                     String triggerName = SchemalessFunctions.generateSequenceTriggerName((IntegerColumn) c);
                     sql = String.format(
-                        "SELECT proc.RDB$DEPENDED_ON_NAME %n "
-                            + "FROM RDB$DEPENDENCIES tr%n "
-                            + "JOIN RDB$DEPENDENCIES proc ON tr.RDB$DEPENDED_ON_NAME = proc.RDB$DEPENDENT_NAME%n "
-                            + "WHERE tr.RDB$DEPENDENT_NAME = '%s' AND tr.RDB$DEPENDENT_TYPE = 2 "
-                            + "AND tr.RDB$DEPENDED_ON_TYPE = 5%n "
-                            + "AND proc.RDB$DEPENDENT_TYPE = 5 AND proc.RDB$DEPENDED_ON_TYPE = 14",
-                        triggerName
+                            "SELECT proc.RDB$DEPENDED_ON_NAME %n "
+                                    + "FROM RDB$DEPENDENCIES tr%n "
+                                    + "JOIN RDB$DEPENDENCIES proc ON tr.RDB$DEPENDED_ON_NAME = proc.RDB$DEPENDENT_NAME%n "
+                                    + "WHERE tr.RDB$DEPENDENT_NAME = '%s' AND tr.RDB$DEPENDENT_TYPE = 2 "
+                                    + "AND tr.RDB$DEPENDED_ON_TYPE = 5%n "
+                                    + "AND proc.RDB$DEPENDENT_TYPE = 5 AND proc.RDB$DEPENDED_ON_TYPE = 14",
+                            triggerName
                     );
 
                     try (ResultSet sequenceRs = SqlUtils.executeQuery(conn, sql)) {
                         if (sequenceRs.next()) {
                             String sequenceName = sequenceRs.getString(1).trim();
                             defaultValue = "NEXTVAL("
-                                // TODO: score sequence name could be spoiled here because of name limitation
-                                + sequenceName.replace(g.getName() + "_", "")
-                                + ")";
+                                    // TODO: score sequence name could be spoiled here because of name limitation
+                                    + sequenceName.replace(g.getName() + "_", "")
+                                    + ")";
                         }
                     }
                 }
@@ -501,17 +502,17 @@ public final class FirebirdAdaptor extends DBAdaptor {
     @Override
     public DbPkInfo getPKInfo(Connection conn, TableElement t) {
         String sql = String.format(
-            "select%n"
-                + "    ix.rdb$index_name as pk_name,%n"
-                + "    sg.rdb$field_name as column_name%n"
-                + " from%n"
-                + "    rdb$indices ix%n"
-                + "    left join rdb$index_segments sg on ix.rdb$index_name = sg.rdb$index_name%n"
-                + "    left join rdb$relation_constraints rc on rc.rdb$index_name = ix.rdb$index_name%n"
-                + " where%n"
-                + "    rc.rdb$constraint_type = 'PRIMARY KEY' AND rc.rdb$relation_name = '%s_%s'",
-            t.getGrain().getName(),
-            t.getName()
+                "select%n"
+                        + "    ix.rdb$index_name as pk_name,%n"
+                        + "    sg.rdb$field_name as column_name%n"
+                        + " from%n"
+                        + "    rdb$indices ix%n"
+                        + "    left join rdb$index_segments sg on ix.rdb$index_name = sg.rdb$index_name%n"
+                        + "    left join rdb$relation_constraints rc on rc.rdb$index_name = ix.rdb$index_name%n"
+                        + " where%n"
+                        + "    rc.rdb$constraint_type = 'PRIMARY KEY' AND rc.rdb$relation_name = '%s_%s'",
+                t.getGrain().getName(),
+                t.getName()
         );
 
         DbPkInfo result = new DbPkInfo(this);
@@ -537,26 +538,26 @@ public final class FirebirdAdaptor extends DBAdaptor {
     @Override
     public List<DbFkInfo> getFKInfo(Connection conn, Grain g) {
         String sql = String.format(
-                "SELECT" +
-                "    detail_relation_constraints.RDB$RELATION_NAME as table_name%n" +
-                "    , detail_relation_constraints.RDB$CONSTRAINT_NAME as constraint_name%n" +
-                "    , ref_constraints.RDB$UPDATE_RULE as update_rule%n" +
-                "    , ref_constraints.RDB$DELETE_RULE as delete_rule%n" +
-                "    , detail_index_segments.rdb$field_name AS column_name%n" +
-                "    , master_relation_constraints.rdb$relation_name AS ref_table_name%n" +
-                "FROM%n" +
-                "    rdb$relation_constraints detail_relation_constraints%n" +
-                "    JOIN rdb$index_segments detail_index_segments ON " +
-                "      detail_relation_constraints.rdb$index_name = detail_index_segments.rdb$index_name %n" +
-                "    JOIN rdb$ref_constraints ref_constraints ON " +
-                "      detail_relation_constraints.rdb$constraint_name = ref_constraints.rdb$constraint_name%n" +
-                "    JOIN rdb$relation_constraints master_relation_constraints ON " +
-                "      ref_constraints.rdb$const_name_uq = master_relation_constraints.rdb$constraint_name%n" +
-                "WHERE%n" +
-                "    detail_relation_constraints.rdb$constraint_type = 'FOREIGN KEY'%n" +
-                "    AND detail_relation_constraints.rdb$relation_name like '%s@_%%' escape '@'%n" +
-                "ORDER BY table_name, constraint_name, detail_index_segments.rdb$field_position;",
-            g.getName()
+                "SELECT"
+                        + "    detail_relation_constraints.RDB$RELATION_NAME as table_name%n"
+                        + "    , detail_relation_constraints.RDB$CONSTRAINT_NAME as constraint_name%n"
+                        + "    , ref_constraints.RDB$UPDATE_RULE as update_rule%n"
+                        + "    , ref_constraints.RDB$DELETE_RULE as delete_rule%n"
+                        + "    , detail_index_segments.rdb$field_name AS column_name%n"
+                        + "    , master_relation_constraints.rdb$relation_name AS ref_table_name%n"
+                        + "FROM%n"
+                        + "    rdb$relation_constraints detail_relation_constraints%n"
+                        + "    JOIN rdb$index_segments detail_index_segments ON "
+                        + "      detail_relation_constraints.rdb$index_name = detail_index_segments.rdb$index_name %n"
+                        + "    JOIN rdb$ref_constraints ref_constraints ON "
+                        + "      detail_relation_constraints.rdb$constraint_name = ref_constraints.rdb$constraint_name%n"
+                        + "    JOIN rdb$relation_constraints master_relation_constraints ON "
+                        + "      ref_constraints.rdb$const_name_uq = master_relation_constraints.rdb$constraint_name%n"
+                        + "WHERE%n"
+                        + "    detail_relation_constraints.rdb$constraint_type = 'FOREIGN KEY'%n"
+                        + "    AND detail_relation_constraints.rdb$relation_name like '%s@_%%' escape '@'%n"
+                        + "ORDER BY table_name, constraint_name, detail_index_segments.rdb$field_position;",
+                g.getName()
         );
 
         Map<String, DbFkInfo> fks = new HashMap<>();
@@ -578,18 +579,18 @@ public final class FirebirdAdaptor extends DBAdaptor {
                 String columnName = rs.getString("column_name").trim();
 
                 fks.computeIfAbsent(
-                    fkName,
-                    key -> {
-                        DbFkInfo dfi = new DbFkInfo(fkName);
+                        fkName,
+                        key -> {
+                            DbFkInfo dfi = new DbFkInfo(fkName);
 
-                        dfi.setTableName(tableName);
-                        dfi.setRefGrainName(refGrainName);
-                        dfi.setRefTableName(refTableName);
-                        dfi.setDeleteRule(deleteRule);
-                        dfi.setUpdateRule(updateRule);
+                            dfi.setTableName(tableName);
+                            dfi.setRefGrainName(refGrainName);
+                            dfi.setRefTableName(refTableName);
+                            dfi.setDeleteRule(deleteRule);
+                            dfi.setUpdateRule(updateRule);
 
-                        return dfi;
-                    }
+                            return dfi;
+                        }
                 ).getColumnNames().add(columnName);
 
             }
@@ -604,17 +605,17 @@ public final class FirebirdAdaptor extends DBAdaptor {
     @Override
     public Map<String, DbIndexInfo> getIndices(Connection conn, Grain g) {
         String sql = String.format(
-            "SELECT RDB$INDICES.RDB$INDEX_NAME as indexname, RDB$INDICES.RDB$RELATION_NAME as tablename, "
-                + "RDB$INDEX_SEGMENTS.RDB$FIELD_NAME AS columnname%n"
-                + "FROM RDB$INDEX_SEGMENTS%n"
-                + "LEFT JOIN RDB$INDICES "
-                + " ON RDB$INDICES.RDB$INDEX_NAME = RDB$INDEX_SEGMENTS.RDB$INDEX_NAME%n"
-                + "LEFT JOIN RDB$RELATION_CONSTRAINTS "
-                + " ON RDB$RELATION_CONSTRAINTS.RDB$INDEX_NAME = RDB$INDEX_SEGMENTS.RDB$INDEX_NAME%n"
-                + "WHERE RDB$RELATION_CONSTRAINTS.RDB$CONSTRAINT_TYPE IS NULL "
-                + "AND RDB$INDICES.RDB$RELATION_NAME like '%s@_%%' escape '@'%n"
-                + "ORDER BY RDB$INDEX_SEGMENTS.RDB$FIELD_POSITION",
-            g.getName()
+                "SELECT RDB$INDICES.RDB$INDEX_NAME as indexname, RDB$INDICES.RDB$RELATION_NAME as tablename, "
+                        + "RDB$INDEX_SEGMENTS.RDB$FIELD_NAME AS columnname%n"
+                        + "FROM RDB$INDEX_SEGMENTS%n"
+                        + "LEFT JOIN RDB$INDICES "
+                        + " ON RDB$INDICES.RDB$INDEX_NAME = RDB$INDEX_SEGMENTS.RDB$INDEX_NAME%n"
+                        + "LEFT JOIN RDB$RELATION_CONSTRAINTS "
+                        + " ON RDB$RELATION_CONSTRAINTS.RDB$INDEX_NAME = RDB$INDEX_SEGMENTS.RDB$INDEX_NAME%n"
+                        + "WHERE RDB$RELATION_CONSTRAINTS.RDB$CONSTRAINT_TYPE IS NULL "
+                        + "AND RDB$INDICES.RDB$RELATION_NAME like '%s@_%%' escape '@'%n"
+                        + "ORDER BY RDB$INDEX_SEGMENTS.RDB$FIELD_POSITION",
+                g.getName()
         );
 
         Map<String, DbIndexInfo> result = new HashMap<>();
@@ -648,11 +649,11 @@ public final class FirebirdAdaptor extends DBAdaptor {
         // TODO: grain names may be cut, so reconsider the following
         String sql = String.format(
                 "SELECT RDB$PROCEDURE_NAME%n"
-              + "FROM RDB$PROCEDURES%n"
-              + "WHERE RDB$PROCEDURE_NAME LIKE '%s@_%%' escape '@' %n"
-                + "AND RDB$PROCEDURE_NAME NOT LIKE '%%" + CUR_VALUE_PROC_POSTFIX + "%%' escape '@' %n"
-                + "AND RDB$PROCEDURE_NAME NOT LIKE '%%" + NEXT_VALUE_PROC_POSTFIX + "%%' escape '@' %n",
-            g.getName()
+                        + "FROM RDB$PROCEDURES%n"
+                        + "WHERE RDB$PROCEDURE_NAME LIKE '%s@_%%' escape '@' %n"
+                        + "AND RDB$PROCEDURE_NAME NOT LIKE '%%" + CUR_VALUE_PROC_POSTFIX + "%%' escape '@' %n"
+                        + "AND RDB$PROCEDURE_NAME NOT LIKE '%%" + NEXT_VALUE_PROC_POSTFIX + "%%' escape '@' %n",
+                g.getName()
         );
 
         try (ResultSet rs = SqlUtils.executeQuery(conn, sql)) {
@@ -670,8 +671,8 @@ public final class FirebirdAdaptor extends DBAdaptor {
     @Override
     public int getDBPid(Connection conn) {
         try (
-            ResultSet rs = SqlUtils.executeQuery(
-                conn, "SELECT MON$SERVER_PID as pid FROM MON$ATTACHMENTS")
+                ResultSet rs = SqlUtils.executeQuery(
+                        conn, "SELECT MON$SERVER_PID as pid FROM MON$ATTACHMENTS")
         ) {
             if (rs.next()) {
                 return rs.getInt("pid");
@@ -699,7 +700,7 @@ public final class FirebirdAdaptor extends DBAdaptor {
             return rs.getLong(1);
         } catch (SQLException e) {
             throw new CelestaException(
-                "Can't get current value of sequence " + tableString(s.getGrain().getName(), s.getName()), e
+                    "Can't get current value of sequence " + tableString(s.getGrain().getName(), s.getName()), e
             );
         }
     }
@@ -753,7 +754,7 @@ public final class FirebirdAdaptor extends DBAdaptor {
     @Override
     public boolean sequenceExists(Connection conn, String schema, String name) {
         String sql = String.format("SELECT * FROM RDB$GENERATORS WHERE RDB$GENERATOR_NAME = '%s'",
-                                   sequenceString(schema, name, false));
+                sequenceString(schema, name, false));
 
         try (ResultSet rs = SqlUtils.executeQuery(conn, sql)) {
             return rs.next();
@@ -767,8 +768,8 @@ public final class FirebirdAdaptor extends DBAdaptor {
         String nextValueProcName = sequenceNextValueProcString(s.getGrain().getName(), s.getName(), false);
 
         String sql = String.format("SELECT RDB$PROCEDURE_SOURCE FROM RDB$PROCEDURES "
-                                 + "WHERE RDB$PROCEDURE_NAME = '%s'",
-                                   nextValueProcName);
+                        + "WHERE RDB$PROCEDURE_NAME = '%s'",
+                nextValueProcName);
 
         try (ResultSet rs = SqlUtils.executeQuery(conn, sql)) {
             rs.next();
@@ -810,8 +811,8 @@ public final class FirebirdAdaptor extends DBAdaptor {
 
         for (int i = 0; i < fields.size(); ++i) {
             sb.append(tableStr).append(".\"").append(fields.get(i)).append("\"")
-                .append(" = ")
-                .append(otherTableStr).append(".\"").append(otherFields.get(i)).append("\"");
+                    .append(" = ")
+                    .append(otherTableStr).append(".\"").append(otherFields.get(i)).append("\"");
 
             if (i + 1 != fields.size()) {
                 sb.append(" AND ");
@@ -826,9 +827,9 @@ public final class FirebirdAdaptor extends DBAdaptor {
     @Override
     public void createSysObjects(Connection conn, String sysSchemaName) {
         String versionCheckErrorSql =
-            "CREATE OR ALTER EXCEPTION VERSION_CHECK_ERROR 'record version check failure'";
+                "CREATE OR ALTER EXCEPTION VERSION_CHECK_ERROR 'record version check failure'";
         String sequenceOverflowErrorSql =
-            "CREATE OR ALTER EXCEPTION SEQUENCE_OVERFLOW_ERROR 'sequence overflow failure'";
+                "CREATE OR ALTER EXCEPTION SEQUENCE_OVERFLOW_ERROR 'sequence overflow failure'";
 
         try {
             try (Statement stmt = conn.createStatement()) {
@@ -845,12 +846,12 @@ public final class FirebirdAdaptor extends DBAdaptor {
         List<String> result = new ArrayList<>();
 
         String sql = String.format(
-            "select rdb$relation_name%n"
-            + "from rdb$relations%n"
-            + "where rdb$view_blr is not null %n"
-            + "and (rdb$system_flag is null or rdb$system_flag = 0)"
-            + "and rdb$relation_name like '%s@_%%' escape '@'",
-            g.getName()
+                "select rdb$relation_name%n"
+                        + "from rdb$relations%n"
+                        + "where rdb$view_blr is not null %n"
+                        + "and (rdb$system_flag is null or rdb$system_flag = 0)"
+                        + "and rdb$relation_name like '%s@_%%' escape '@'",
+                g.getName()
         );
 
         try (ResultSet rs = SqlUtils.executeQuery(conn, sql)) {

--- a/celesta-sql/src/main/java/ru/curs/celesta/dbutils/adaptors/FirebirdAdaptor.java
+++ b/celesta-sql/src/main/java/ru/curs/celesta/dbutils/adaptors/FirebirdAdaptor.java
@@ -554,7 +554,7 @@ public final class FirebirdAdaptor extends DBAdaptor {
                 "      ref_constraints.rdb$const_name_uq = master_relation_constraints.rdb$constraint_name%n" +
                 "WHERE%n" +
                 "    detail_relation_constraints.rdb$constraint_type = 'FOREIGN KEY'%n" +
-                "    AND detail_relation_constraints.rdb$relation_name = like '%s@_%%' escape '@'%n" +
+                "    AND detail_relation_constraints.rdb$relation_name like '%s@_%%' escape '@'%n" +
                 "ORDER BY constraint_name, column_name, detail_index_segments.rdb$field_position;",
             g.getName()
         );

--- a/celesta-sql/src/main/java/ru/curs/celesta/dbutils/adaptors/ddl/DdlAdaptor.java
+++ b/celesta-sql/src/main/java/ru/curs/celesta/dbutils/adaptors/ddl/DdlAdaptor.java
@@ -4,7 +4,17 @@ import ru.curs.celesta.CelestaException;
 import ru.curs.celesta.dbutils.meta.DbColumnInfo;
 import ru.curs.celesta.dbutils.meta.DbIndexInfo;
 import ru.curs.celesta.event.TriggerQuery;
-import ru.curs.celesta.score.*;
+import ru.curs.celesta.score.BasicTable;
+import ru.curs.celesta.score.Column;
+import ru.curs.celesta.score.ForeignKey;
+import ru.curs.celesta.score.Grain;
+import ru.curs.celesta.score.Index;
+import ru.curs.celesta.score.MaterializedView;
+import ru.curs.celesta.score.ParameterizedView;
+import ru.curs.celesta.score.SQLGenerator;
+import ru.curs.celesta.score.SequenceElement;
+import ru.curs.celesta.score.TableElement;
+import ru.curs.celesta.score.View;
 
 import java.sql.Connection;
 import java.sql.SQLException;

--- a/celesta-sql/src/main/java/ru/curs/celesta/dbutils/adaptors/ddl/DdlAdaptor.java
+++ b/celesta-sql/src/main/java/ru/curs/celesta/dbutils/adaptors/ddl/DdlAdaptor.java
@@ -382,15 +382,7 @@ public final class DdlAdaptor {
     }
 
     private void processSql(Connection conn, String sql) {
-        if ("COMMIT".equalsIgnoreCase(sql)) {
-            try {
-                conn.commit();
-            } catch (SQLException e) {
-                throw new CelestaException(e);
-            }
-        } else {
-            ddlConsumer.consume(conn, sql);
-        }
+        ddlConsumer.consume(conn, sql);
     }
 
     private void processSql(Connection conn, Collection<String> sqlList) {

--- a/celesta-sql/src/main/java/ru/curs/celesta/dbutils/adaptors/ddl/JdbcDdlConsumer.java
+++ b/celesta-sql/src/main/java/ru/curs/celesta/dbutils/adaptors/ddl/JdbcDdlConsumer.java
@@ -1,12 +1,22 @@
 package ru.curs.celesta.dbutils.adaptors.ddl;
 
+import ru.curs.celesta.CelestaException;
 import ru.curs.celesta.dbutils.jdbc.SqlUtils;
 
 import java.sql.Connection;
+import java.sql.SQLException;
 
 public class JdbcDdlConsumer implements DdlConsumer {
     @Override
     public void consume(Connection conn, String sql)  {
-        SqlUtils.executeUpdate(conn, sql);
+        if ("COMMIT".equalsIgnoreCase(sql)) {
+            try {
+                conn.commit();
+            } catch (SQLException e) {
+                throw new CelestaException(e);
+            }
+        } else {
+            SqlUtils.executeUpdate(conn, sql);
+        }
     }
 }

--- a/celesta-system-services/pom.xml
+++ b/celesta-system-services/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>celesta-parent</artifactId>
         <groupId>ru.curs</groupId>
-        <version>7.2.14-SNAPSHOT</version>
+        <version>7.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-core</artifactId>
-            <version>7.2.14-SNAPSHOT</version>
+            <version>7.3.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/celesta-test/pom.xml
+++ b/celesta-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>celesta-parent</artifactId>
         <groupId>ru.curs</groupId>
-        <version>7.2.14-SNAPSHOT</version>
+        <version>7.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -44,14 +44,14 @@
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-system-services</artifactId>
-            <version>7.2.14-SNAPSHOT</version>
+            <version>7.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-core</artifactId>
-            <version>7.2.14-SNAPSHOT</version>
+            <version>7.3.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/celesta-test/src/test/java/ru/curs/celesta/dbutils/adaptors/AbstractAdaptorTest.java
+++ b/celesta-test/src/test/java/ru/curs/celesta/dbutils/adaptors/AbstractAdaptorTest.java
@@ -94,9 +94,9 @@ public abstract class AbstractAdaptorTest {
         from.setExpression(dba.tableString(ge.getGrain().getName(), ge.getName()));
 
         try (PreparedStatement stmt = dba.getSetCountStatement(conn, from, "")) {
-                ResultSet rs = stmt.executeQuery();
-                rs.next();
-                return rs.getInt(1);
+            ResultSet rs = stmt.executeQuery();
+            rs.next();
+            return rs.getInt(1);
         }
     }
 
@@ -280,7 +280,7 @@ public abstract class AbstractAdaptorTest {
 
             boolean[] mask = {true, true, false, true, true, true, true, true, true, true, true, true, true, false, true, true};
             boolean[] nullsMask = {false, false, false, false, false, false, false, false, false, false, false, false,
-                false, false, false, false};
+                    false, false, false, false};
             Integer[] rec = {1, null, 22, null, null, null, null, null, null, null, null, null, null, null, null};
             program = new ArrayList<>();
             w = WhereTermsMaker.getPKWhereTerm(t);
@@ -1147,6 +1147,34 @@ public abstract class AbstractAdaptorTest {
     }
 
     @Test
+    public void additionalFKTest() throws ParseException {
+        Grain g = score.getGrain(GRAIN_NAME);
+        SequenceElement t3s = g.getElement("aLongIdentityTableNxx_f1", SequenceElement.class);
+        BasicTable t3 = g.getElement("aLongIdentityTableNaaame", BasicTable.class);
+        BasicTable t4 = g.getElement("refTo2", BasicTable.class);
+        Set<ForeignKey> foreignKeys = t3.getForeignKeys();
+        try {
+            dba.createSequence(conn, t3s);
+            dba.createTable(conn, t3);
+            dba.createTable(conn, t4);
+            for (ForeignKey fk : foreignKeys)
+                dba.createFK(conn, fk);
+            List<DbFkInfo> fkInfo = dba.getFKInfo(conn, g);
+            for (DbFkInfo i : fkInfo) {
+                assertTrue(Collections.singletonList("field2").equals(i.getColumnNames())
+                        || Collections.singletonList("field3").equals(i.getColumnNames()));
+            }
+        } catch (Exception ex) {
+            // TODO: When can it happen?
+            LOGGER.error("Error", ex);
+        } finally {
+            dba.dropTable(conn, t3);
+            dba.dropSequence(conn, t3s);
+        }
+    }
+
+
+    @Test
     public void additionalCreateTableTest() throws ParseException {
         Grain g = score.getGrain(GRAIN_NAME);
         SequenceElement t3s = g.getElement("aLongIdentityTableNxx_f1", SequenceElement.class);
@@ -1217,49 +1245,49 @@ public abstract class AbstractAdaptorTest {
         insertRow(conn, t, 2);
 
 
-            String orderBy = t.getColumn("id").getQuotedName();
+        String orderBy = t.getColumn("id").getQuotedName();
 
 
-            FromClause from = new FromClause();
-            from.setGe(t);
-            from.setExpression(dba.tableString(t.getGrain().getName(), t.getName()));
+        FromClause from = new FromClause();
+        from.setGe(t);
+        from.setExpression(dba.tableString(t.getGrain().getName(), t.getName()));
 
-            int count = 0;
-            try (
+        int count = 0;
+        try (
                 PreparedStatement stmt = dba.getRecordSetStatement(
-                    conn, from, "", orderBy, 0, 0, Collections.emptySet()
+                        conn, from, "", orderBy, 0, 0, Collections.emptySet()
                 )
-            ) {
-                ResultSet rs = stmt.executeQuery();
-                while (rs.next()) {
-                    ++count;
-                }
-                assertEquals(2, count);
+        ) {
+            ResultSet rs = stmt.executeQuery();
+            while (rs.next()) {
+                ++count;
             }
+            assertEquals(2, count);
+        }
 
-            count = 0;
-            try (
+        count = 0;
+        try (
                 PreparedStatement stmt = dba.getRecordSetStatement(
-                    conn, from, "", orderBy, 1, 0, Collections.emptySet()
+                        conn, from, "", orderBy, 1, 0, Collections.emptySet()
                 )
-            ) {
-                ResultSet rs = stmt.executeQuery();
-                while (rs.next()) {
-                    ++count;
-                }
-                assertEquals(1, count);
+        ) {
+            ResultSet rs = stmt.executeQuery();
+            while (rs.next()) {
+                ++count;
             }
+            assertEquals(1, count);
+        }
 
-            count = 0;
-            try (PreparedStatement stmt = dba.getRecordSetStatement(
-                    conn, from, "", orderBy, 0, 1, Collections.emptySet()
-            )) {
-                ResultSet rs = stmt.executeQuery();
-                while (rs.next()) {
-                    ++count;
-                }
-                assertEquals(1, count);
+        count = 0;
+        try (PreparedStatement stmt = dba.getRecordSetStatement(
+                conn, from, "", orderBy, 0, 1, Collections.emptySet()
+        )) {
+            ResultSet rs = stmt.executeQuery();
+            while (rs.next()) {
+                ++count;
             }
+            assertEquals(1, count);
+        }
 
     }
 
@@ -1308,7 +1336,7 @@ public abstract class AbstractAdaptorTest {
 
                 d = d.plusSeconds(1);
                 Object[] rowData2 = {null, "A", 5, Date.from(
-                    d.toInstant(ZoneOffset.UTC))};
+                        d.toInstant(ZoneOffset.UTC))};
                 i = 1;
                 for (ParameterSetter ps : program) {
                     ps.execute(pstmt, i++, rowData2, 0);
@@ -1340,9 +1368,9 @@ public abstract class AbstractAdaptorTest {
             from.setExpression(dba.tableString(mv.getGrain().getName(), mv.getName()));
 
             try (
-                PreparedStatement pstmt = dba.getRecordSetStatement(
-                    conn, from, "", "\"var\"", 0, 0, Collections.emptySet()
-            )) {
+                    PreparedStatement pstmt = dba.getRecordSetStatement(
+                            conn, from, "", "\"var\"", 0, 0, Collections.emptySet()
+                    )) {
                 ResultSet rs = pstmt.executeQuery();
 
                 rs.next();
@@ -1614,9 +1642,9 @@ public abstract class AbstractAdaptorTest {
 
             final DbColumnInfo idInfo1 = dba.getColumnInfo(conn, table.getColumn("id"));
             assertAll(
-                () -> assertTrue(idInfo1.reflects(id)),
-                () -> assertEquals(IntegerColumn.class, idInfo1.getType()),
-                () -> assertEquals("NEXTVAL(testSequence)".toLowerCase(), idInfo1.getDefaultValue().toLowerCase())
+                    () -> assertTrue(idInfo1.reflects(id)),
+                    () -> assertEquals(IntegerColumn.class, idInfo1.getType()),
+                    () -> assertEquals("NEXTVAL(testSequence)".toLowerCase(), idInfo1.getDefaultValue().toLowerCase())
             );
 
             id.setNullableAndDefault(false, "NEXTVAL(" + sequence2.getName() + ")");
@@ -1625,9 +1653,9 @@ public abstract class AbstractAdaptorTest {
 
             final DbColumnInfo idInfo2 = dba.getColumnInfo(conn, table.getColumn("id"));
             assertAll(
-                () -> assertTrue(idInfo2.reflects(id)),
-                () -> assertEquals(IntegerColumn.class, idInfo2.getType()),
-                () -> assertEquals("NEXTVAL(testSequence2)".toLowerCase(), idInfo2.getDefaultValue().toLowerCase())
+                    () -> assertTrue(idInfo2.reflects(id)),
+                    () -> assertEquals(IntegerColumn.class, idInfo2.getType()),
+                    () -> assertEquals("NEXTVAL(testSequence2)".toLowerCase(), idInfo2.getDefaultValue().toLowerCase())
             );
 
             id.setNullableAndDefault(false, "5");
@@ -1636,9 +1664,9 @@ public abstract class AbstractAdaptorTest {
 
             final DbColumnInfo idInfo3 = dba.getColumnInfo(conn, table.getColumn("id"));
             assertAll(
-                () -> assertTrue(idInfo3.reflects(id)),
-                () -> assertEquals(IntegerColumn.class, idInfo3.getType()),
-                () -> assertEquals("5".toLowerCase(), idInfo3.getDefaultValue().toLowerCase())
+                    () -> assertTrue(idInfo3.reflects(id)),
+                    () -> assertEquals(IntegerColumn.class, idInfo3.getType()),
+                    () -> assertEquals("5".toLowerCase(), idInfo3.getDefaultValue().toLowerCase())
             );
 
             id.setNullableAndDefault(false, "NEXTVAL(" + sequence.getName() + ")");
@@ -1647,18 +1675,18 @@ public abstract class AbstractAdaptorTest {
 
             final DbColumnInfo idInfo4 = dba.getColumnInfo(conn, table.getColumn("id"));
             assertAll(
-                () -> assertTrue(idInfo4.reflects(id)),
-                () -> assertEquals(IntegerColumn.class, idInfo4.getType()),
-                () -> assertEquals("NEXTVAL(testSequence)".toLowerCase(), idInfo4.getDefaultValue().toLowerCase())
+                    () -> assertTrue(idInfo4.reflects(id)),
+                    () -> assertEquals(IntegerColumn.class, idInfo4.getType()),
+                    () -> assertEquals("NEXTVAL(testSequence)".toLowerCase(), idInfo4.getDefaultValue().toLowerCase())
             );
 
 
             IntegerColumn numb = (IntegerColumn) table.getColumn("numb");
             final DbColumnInfo numbInfo1 = dba.getColumnInfo(conn, numb);
             assertAll(
-                () -> assertTrue(numbInfo1.reflects(numb)),
-                () -> assertEquals(IntegerColumn.class, numbInfo1.getType()),
-                () -> assertTrue(numbInfo1.getDefaultValue().isEmpty())
+                    () -> assertTrue(numbInfo1.reflects(numb)),
+                    () -> assertEquals(IntegerColumn.class, numbInfo1.getType()),
+                    () -> assertTrue(numbInfo1.getDefaultValue().isEmpty())
             );
 
             numb.setNullableAndDefault(false, "NEXTVAL(" + sequence2.getName() + ")");
@@ -1666,9 +1694,9 @@ public abstract class AbstractAdaptorTest {
             dba.updateColumn(conn, numb, numbInfo1);
             final DbColumnInfo numbInfo2 = dba.getColumnInfo(conn, numb);
             assertAll(
-                () -> assertTrue(numbInfo2.reflects(numb)),
-                () -> assertEquals(IntegerColumn.class, numbInfo2.getType()),
-                () -> assertEquals("NEXTVAL(testSequence2)".toLowerCase(), numbInfo2.getDefaultValue().toLowerCase())
+                    () -> assertTrue(numbInfo2.reflects(numb)),
+                    () -> assertEquals(IntegerColumn.class, numbInfo2.getType()),
+                    () -> assertEquals("NEXTVAL(testSequence2)".toLowerCase(), numbInfo2.getDefaultValue().toLowerCase())
             );
         } finally {
             if (dba.tableExists(conn, g.getName(), table.getName()))

--- a/celesta-test/src/test/java/ru/curs/celesta/dbutils/adaptors/AbstractAdaptorTest.java
+++ b/celesta-test/src/test/java/ru/curs/celesta/dbutils/adaptors/AbstractAdaptorTest.java
@@ -1153,6 +1153,7 @@ public abstract class AbstractAdaptorTest {
         BasicTable t3 = g.getElement("aLongIdentityTableNaaame", BasicTable.class);
         BasicTable t4 = g.getElement("refTo2", BasicTable.class);
         Set<ForeignKey> foreignKeys = t3.getForeignKeys();
+        assertFalse(dba.sequenceExists(conn, t3s.getGrain().getName(), t3s.getName()), "sequence exists before");
         try {
             dba.createSequence(conn, t3s);
             dba.createTable(conn, t3);
@@ -1169,8 +1170,11 @@ public abstract class AbstractAdaptorTest {
             LOGGER.error("Error", ex);
         } finally {
             dba.dropTable(conn, t3);
+            dba.dropTable(conn, t4);
             dba.dropSequence(conn, t3s);
         }
+        assertFalse(dba.sequenceExists(conn, t3s.getGrain().getName(), t3s.getName()), "sequence exists after");
+
     }
 
 
@@ -1179,6 +1183,8 @@ public abstract class AbstractAdaptorTest {
         Grain g = score.getGrain(GRAIN_NAME);
         SequenceElement t3s = g.getElement("aLongIdentityTableNxx_f1", SequenceElement.class);
         BasicTable t3 = g.getElement("aLongIdentityTableNaaame", BasicTable.class);
+        assertFalse(dba.sequenceExists(conn, t3s.getGrain().getName(), t3s.getName()), "sequence exists before");
+
         try {
             dba.createSequence(conn, t3s);
             dba.createTable(conn, t3);
@@ -1193,6 +1199,8 @@ public abstract class AbstractAdaptorTest {
             dba.dropTable(conn, t3);
             dba.dropSequence(conn, t3s);
         }
+        assertFalse(dba.sequenceExists(conn, t3s.getGrain().getName(), t3s.getName()), "sequence exists after");
+
     }
 
     @Test

--- a/celesta-test/src/test/java/ru/curs/celesta/dbutils/adaptors/AbstractAdaptorTest.java
+++ b/celesta-test/src/test/java/ru/curs/celesta/dbutils/adaptors/AbstractAdaptorTest.java
@@ -1170,7 +1170,9 @@ public abstract class AbstractAdaptorTest {
                     ));
             assertEquals(2, fkInfo.size());
             assertEquals(Collections.singletonList("idA"), fkInfo.get("refA").getColumnNames());
-            assertEquals(Collections.singletonList("idB"), fkInfo.get("refB").getColumnNames());
+            assertEquals(Arrays.asList("idB2", "idB1"), fkInfo.get("refB").getColumnNames());
+            assertNotEquals(FKRule.CASCADE, fkInfo.get("refA").getDeleteRule());
+            assertEquals(FKRule.CASCADE, fkInfo.get("refB").getDeleteRule());
         } finally {
             dba.dropTable(conn, oneToTwo);
             dba.dropTable(conn, refA);

--- a/celesta-test/src/test/java/ru/curs/celesta/dbutils/adaptors/AbstractAdaptorTest.java
+++ b/celesta-test/src/test/java/ru/curs/celesta/dbutils/adaptors/AbstractAdaptorTest.java
@@ -1118,10 +1118,8 @@ public abstract class AbstractAdaptorTest {
             assertEquals(1, l.size());
             DbFkInfo info = l.get(0);
             assertEquals("fk_testNameVeryVeryLongLonName", info.getName());
-            String[] expected = {"attrVarchar", "attrInt"};
-            String[] actual = info.getColumnNames().toArray(new String[0]);
 
-            assertTrue(Arrays.equals(expected, actual));
+            assertEquals(Arrays.asList("attrVarchar", "attrInt"), info.getColumnNames());
             assertEquals(FKRule.CASCADE, info.getUpdateRule());
             assertEquals(FKRule.SET_NULL, info.getDeleteRule());
 
@@ -1453,7 +1451,6 @@ public abstract class AbstractAdaptorTest {
 
         ParameterizedView pView = g.getElement(pViewName, ParameterizedView.class);
         dba.createParameterizedView(conn, pView);
-
         dba.dropParameterizedView(conn, g.getName(), pViewName);
         assertEquals(0, list.size());
     }

--- a/celesta-test/testScore/gtest/_gtest.sql
+++ b/celesta-test/testScore/gtest/_gtest.sql
@@ -103,3 +103,19 @@ CREATE TABLE tableForTestSequence(
   numb int,
   CONSTRAINT Pk_gtest_tableForTestSequence PRIMARY KEY (id)
 );
+
+create table refA(
+  id int not null primary key,
+  descr varchar(5)
+);
+
+create table refB(
+  id int not null primary key,
+  descr varchar(5)
+);
+
+create table oneToTwo(
+  id int not null primary key,
+  idA int foreign key references refA(id),
+  idB int foreign key references refB(id)
+);

--- a/celesta-test/testScore/gtest/_gtest.sql
+++ b/celesta-test/testScore/gtest/_gtest.sql
@@ -110,12 +110,17 @@ create table refA(
 );
 
 create table refB(
-  id int not null primary key,
-  descr varchar(5)
+  id1 int not null,
+  id2 int not null,
+  descr varchar(5),
+  constraint rbpk primary key(id1, id2)
 );
 
 create table oneToTwo(
   id int not null primary key,
   idA int foreign key references refA(id),
-  idB int foreign key references refB(id)
+  idB2 int,
+  idB1 int,
+  constraint FK_TWO foreign key (idB2, idB1) references refB(id1, id2)
+    on delete cascade
 );

--- a/celesta-unit/pom.xml
+++ b/celesta-unit/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>celesta-parent</artifactId>
         <groupId>ru.curs</groupId>
-        <version>7.2.14-SNAPSHOT</version>
+        <version>7.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -18,13 +18,13 @@
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-core</artifactId>
-            <version>7.2.14-SNAPSHOT</version>
+            <version>7.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-system-services</artifactId>
-            <version>7.2.14-SNAPSHOT</version>
+            <version>7.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>ru.curs</groupId>
     <artifactId>celesta-parent</artifactId>
-    <version>7.2.14-SNAPSHOT</version>
+    <version>7.3.0-SNAPSHOT</version>
     <name>celesta-parent</name>
     <description>celesta - LGPL platform for business logic development</description>
     <packaging>pom</packaging>


### PR DESCRIPTION
## Overview

When there are more than one foreign key in a table, Firebird DBAdaptor incorrectly detects the field sets of the foreign key. (The reason is incorrect SQL query to metadata).

This PR fixes this issue. It also moves the separate treatment of `COMMIT` statetement to `JdbcDdlConsumer` in order to improve support of `2bass`.

Also, version is bumped to 7.3.0.

---

### Checklist

- [x] Change is covered by automated tests.
- [ ] JavaDoc / User Guide is updated.
- [x] CI builds pass.
- [x] PR is tagged.
