### PR TITLE
Remove cursor type limitation for SetIn method

### DIFF
--- a/celesta-core/src/main/java/ru/curs/celesta/dbutils/InFilterHolder.java
+++ b/celesta-core/src/main/java/ru/curs/celesta/dbutils/InFilterHolder.java
@@ -36,10 +36,10 @@ public final class InFilterHolder {
 
         if (cursor instanceof Cursor) {
             fieldsLookup = new FieldsLookup(
-                    (Cursor) cursor, (Cursor) otherCursor, lookupChangeCallback, newLookupCallback);
+                    (Cursor) cursor, otherCursor, lookupChangeCallback, newLookupCallback);
         } else if (cursor instanceof ViewCursor) {
             fieldsLookup = new FieldsLookup(
-                    (ViewCursor) cursor, (ViewCursor) otherCursor, lookupChangeCallback, newLookupCallback);
+                    (ViewCursor) cursor, otherCursor, lookupChangeCallback, newLookupCallback);
         } else {
             throw new CelestaException("Not supported cursor type: %s", cursor.getClass().getSimpleName());
         }

--- a/celesta-documentation/src/main/asciidoc/en/1080_classes.adoc
+++ b/celesta-documentation/src/main/asciidoc/en/1080_classes.adoc
@@ -627,8 +627,6 @@ In this example, if `I1(a1, a2,..)` and `I2(b1, b2,...)` indices are present, th
 [source, java]
 a.setIn(b).add(a.CURSORS.a2(), b.CURSORS.b2());
 
-* The `FieldsLookup` class accepts only the cursors of the same origin, i.e. both cursors should be either table cursors or view cursors.
-
 
 == Sequence Class
 

--- a/celesta-documentation/src/main/asciidoc/ru/1080_classes.adoc
+++ b/celesta-documentation/src/main/asciidoc/ru/1080_classes.adoc
@@ -620,9 +620,6 @@ WHERE aFoo = 'aBar'
 [source, java]
 a.setIn(b).add(a.CURSORS.a2(), b.CURSORS.b2());
 
-* Класс `FieldsLookup` может принять в себя курсоры только одного происхождения, т. е. либо оба курсора для работы с таблицами, либо оба курсора для работы с представлениями.
-
-
 == Класс Sequence
 
 Класс {apidocs}ru/curs/celesta/dbutils/Sequence.html[Sequence] позволяет работать с последовательностями.

--- a/celesta-test/src/test/java/ru/curs/celesta/script/TestFilter.java
+++ b/celesta-test/src/test/java/ru/curs/celesta/script/TestFilter.java
@@ -33,6 +33,20 @@ public class TestFilter implements ScriptTest {
     }
 
     @TestTemplate
+    public void testInFilterForTableToView(CallContext context) throws ParseException {
+        AFilterCursor a = new AFilterCursor(context);
+        BFilterViewCursor b = new BFilterViewCursor(context);
+        _testInFilterForIndices(context, a, b);
+    }
+
+    @TestTemplate
+    public void testInFilterForViewToTable(CallContext context) throws ParseException {
+        AFilterCursor a = new AFilterCursor(context);
+        BFilterViewCursor b = new BFilterViewCursor(context);
+        _testInFilterForIndices(context, a, b);
+    }
+
+    @TestTemplate
     public void testInFilterForSimplePks(CallContext context) throws ParseException {
         CFilterCursor c = new CFilterCursor(context);
         DFilterCursor d = new DFilterCursor(context);
@@ -114,6 +128,14 @@ public class TestFilter implements ScriptTest {
     }
 
     @TestTemplate
+    public void testInFilterWithRangeInMainCursorForTableToView(CallContext context) throws ParseException {
+        AFilterCursor a = new AFilterCursor(context);
+        BFilterViewCursor b = new BFilterViewCursor(context);
+        _testInFilterWithRangeInMainCursor(context, a, b);
+    }
+
+
+    @TestTemplate
     public void testInFilterWithRangeInOtherCursorBeforeSetInForTable(CallContext context) throws ParseException {
         AFilterCursor a = new AFilterCursor(context);
         BFilterCursor b = new BFilterCursor(context);
@@ -123,6 +145,13 @@ public class TestFilter implements ScriptTest {
     @TestTemplate
     public void testInFilterWithRangeInOtherCursorBeforeSetInForView(CallContext context) throws ParseException {
         AFilterViewCursor a = new AFilterViewCursor(context);
+        BFilterViewCursor b = new BFilterViewCursor(context);
+        _testInFilterWithRangeInOtherCursorBeforeSetIn(context, a, b);
+    }
+
+    @TestTemplate
+    public void testInFilterWithRangeInOtherCursorBeforeSetInForTableToView(CallContext context) throws ParseException {
+        AFilterCursor a = new AFilterCursor(context);
         BFilterViewCursor b = new BFilterViewCursor(context);
         _testInFilterWithRangeInOtherCursorBeforeSetIn(context, a, b);
     }
@@ -153,6 +182,14 @@ public class TestFilter implements ScriptTest {
     @TestTemplate
     public void testInFilterWithAdditionalLookupForView(CallContext context) throws ParseException {
         AFilterViewCursor a = new AFilterViewCursor(context);
+        BFilterViewCursor b = new BFilterViewCursor(context);
+        GFilterViewCursor g = new GFilterViewCursor(context);
+        _testInFilterWithAdditionalLookup(context, a, b, g);
+    }
+
+    @TestTemplate
+    public void testInFilterWithAdditionalLookupForTableToView(CallContext context) throws ParseException {
+        AFilterCursor a = new AFilterCursor(context);
         BFilterViewCursor b = new BFilterViewCursor(context);
         GFilterViewCursor g = new GFilterViewCursor(context);
         _testInFilterWithAdditionalLookup(context, a, b, g);


### PR DESCRIPTION
## Overview

The `FieldsLookup` class accepts only the cursors of the same origin, i.e. both cursors should be either table cursors or view cursors.

This limitation is unnecessary and should be removed.

---

### Checklist

- [x] Change is covered by automated tests.
- [x] JavaDoc / User Guide is updated.
- [x] CI builds pass.
- [x] PR is tagged.
