### PR TITLE
documentation fix: close xml tag

### DIFF
--- a/celesta-documentation/src/main/asciidoc/en/1130_celesta_unit.adoc
+++ b/celesta-documentation/src/main/asciidoc/en/1130_celesta_unit.adoc
@@ -26,7 +26,7 @@ To employ these functions, add a CelestaUnit Maven dependency:
 ```xml
 <dependency>
     <groupId>ru.curs</groupId>
-    <artifactId>celesta-unit<artifactId>
+    <artifactId>celesta-unit</artifactId>
     <version>...</version>
     <scope>test</scope>
 </dependency>

--- a/celesta-documentation/src/main/asciidoc/ru/1130_celesta_unit.adoc
+++ b/celesta-documentation/src/main/asciidoc/ru/1130_celesta_unit.adoc
@@ -26,7 +26,7 @@ include::ru/_common_attributes.adoc[]
 ```xml
 <dependency>
     <groupId>ru.curs</groupId>
-    <artifactId>celesta-unit<artifactId>
+    <artifactId>celesta-unit</artifactId>
     <version>...</version>
     <scope>test</scope>
 </dependency>


### PR DESCRIPTION
## Overview

Fix documentation: close XML tag in Maven code snippet.

---

### Checklist

- [x] Change is covered by automated tests.
- [x] JavaDoc / User Guide is updated.
- [x] CI builds pass.
- [x] PR is tagged.
