### PR TITLE
IDEA-friendly error log messages

### DIFF
--- a/celesta-maven-plugin/src/main/java/ru/curs/celesta/plugin/maven/AbstractCelestaMojo.java
+++ b/celesta-maven-plugin/src/main/java/ru/curs/celesta/plugin/maven/AbstractCelestaMojo.java
@@ -62,8 +62,8 @@ abstract class AbstractCelestaMojo extends AbstractMojo {
                     .scoreDiscovery(new ScoreByScorePathDiscovery(scorePath))
                     .build();
             return score;
-        } catch (CelestaException | ParseException e) {
-            throw new CelestaException("Can't init score", e);
+        } catch (ParseException e) {
+            throw new CelestaException(e.getMessage(), e);
         }
     }
 

--- a/celesta-sql/src/main/java/ru/curs/celesta/score/AbstractScore.java
+++ b/celesta-sql/src/main/java/ru/curs/celesta/score/AbstractScore.java
@@ -47,6 +47,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.zip.CRC32;
 
@@ -238,6 +240,15 @@ public abstract class AbstractScore {
                 ));
     }
 
+    static String extractLineColNo(String msg) {
+        Matcher matcher = Pattern.compile("at\\s+line\\s*(\\d+),?\\s*column\\s*(\\d+)").matcher(msg);
+        if (matcher.find()) {
+            return String.format(":%s:%s ", matcher.group(1), matcher.group(2));
+        } else {
+            return "";
+        }
+    }
+
     private ChecksumInputStream parseGrainPart(GrainPart grainPart, ChecksumInputStream cis) throws ParseException {
         Resource r = grainPart.getSource();
         try (
@@ -250,7 +261,11 @@ public abstract class AbstractScore {
             try {
                 parser.parseGrainPart(grainPart);
             } catch (ParseException | TokenMgrError e) {
-                throw new ParseException(String.format("Error parsing '%s': %s", r.toString(), e.getMessage()));
+                /*IntelliJ IDEA-friendly log format*/
+                throw new ParseException(String.format("Error parsing %s%s: %s",
+                        r.toString(),
+                        extractLineColNo(e.getMessage()),
+                        e.getMessage()));
             }
             return is;
         } catch (FileNotFoundException e) {

--- a/celesta-sql/src/test/java/ru/curs/celesta/score/AbstractScoreTest.java
+++ b/celesta-sql/src/test/java/ru/curs/celesta/score/AbstractScoreTest.java
@@ -1,0 +1,17 @@
+package ru.curs.celesta.score;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AbstractScoreTest {
+    @Test
+    void extractLineNo() {
+        assertEquals(":5:8 ", AbstractScore.extractLineColNo("at line 5, column 8"));
+    }
+
+    @Test
+    void emptyStringIfLineNotFound() {
+        assertEquals("", AbstractScore.extractLineColNo("at asdf, column 8"));
+    }
+}


### PR DESCRIPTION
## Overview

Make CelestaSQL parsing error messages IntelliJ IDEA-friendly: adding line and column number after file name after colon enables hyperlinks from error messages

---

### Checklist

- [X] Change is covered by automated tests.
- [ ] JavaDoc / User Guide is updated.
- [x] CI builds pass.
- [x] PR is tagged.
