### PR TITLE
optimize insertions for auto-incremented PKs

### DIFF
--- a/celesta-core/src/main/java/ru/curs/celesta/dbutils/Cursor.java
+++ b/celesta-core/src/main/java/ru/curs/celesta/dbutils/Cursor.java
@@ -182,14 +182,9 @@ public abstract class Cursor extends BasicCursor implements InFilterSupport {
      */
     public final void insert() {
         if (!tryInsert()) {
-            StringBuilder sb = new StringBuilder();
-            for (Object value : _currentKeyValues()) {
-                if (sb.length() > 0) {
-                    sb.append(", ");
-                }
-                sb.append(value == null ? "null" : value.toString());
-            }
-            throw new CelestaException("Record %s (%s) already exists", _objectName(), sb.toString());
+            throw new CelestaException("Record %s %s already exists",
+                    _objectName(),
+                    Arrays.toString(_currentKeyValues()));
         }
     }
 
@@ -288,11 +283,9 @@ public abstract class Cursor extends BasicCursor implements InFilterSupport {
      */
     public final void update() {
         if (!tryUpdate()) {
-            String values = Arrays.stream(_currentKeyValues())
-                    .map(String::valueOf)
-                    .collect(Collectors.joining(", "));
-
-            throw new CelestaException("Record %s (%s) does not exist.", _objectName(), values);
+            throw new CelestaException("Record %s %s does not exist.",
+                    _objectName(),
+                    Arrays.toString(_currentKeyValues()));
         }
     }
 

--- a/celesta-core/src/main/java/ru/curs/celesta/dbutils/Cursor.java
+++ b/celesta-core/src/main/java/ru/curs/celesta/dbutils/Cursor.java
@@ -96,8 +96,10 @@ public abstract class Cursor extends BasicCursor implements InFilterSupport {
 
     };
 
+    private byte canOptimizeInsertion;
     private Cursor xRec;
     private int recversion;
+
 
     public Cursor(CallContext context) {
         super(context);
@@ -205,24 +207,25 @@ public abstract class Cursor extends BasicCursor implements InFilterSupport {
         //TODO: одно из самых нуждающихся в переделке мест.
         // на один insert--2 select-а, что вызывает справедливое возмущение тех, кто смотрит логи
         // 1) Если у нас автоинкремент и автоинкрементное поле в None, то первый select не нужен
+        // (NB 2021-04-14: это реализовано через canOptimizeInsertion)
         // 2) Хорошо бы результат инсерта выдавать в одной операции как resultset
-        PreparedStatement g = getHelper.prepareGet(recversion, _currentKeyValues());
+
         try {
-            ResultSet rs = g.executeQuery();
-            try {
-                if (rs.next()) {
-                    getXRec()._parseResult(rs);
-                    /*
-                     * transmit recversion from xRec to rec for possible future
-                     * record update
-                     */
-                    if (getRecversion() == 0) {
-                        setRecversion(xRec.getRecversion());
+            if (!canOptimizeInsertion()) {
+                PreparedStatement g = getHelper.prepareGet(recversion, _currentKeyValues());
+                try (ResultSet rs = g.executeQuery()) {
+                    if (rs.next()) {
+                        getXRec()._parseResult(rs);
+                        /*
+                         * transmit recversion from xRec to rec for possible future
+                         * record update
+                         */
+                        if (getRecversion() == 0) {
+                            setRecversion(xRec.getRecversion());
+                        }
+                        return false;
                     }
-                    return false;
                 }
-            } finally {
-                rs.close();
             }
 
             PreparedStatement ins = insert.getStatement(_currentValues(), recversion);
@@ -261,6 +264,24 @@ public abstract class Cursor extends BasicCursor implements InFilterSupport {
         return true;
     }
 
+    final boolean canOptimizeInsertion() {
+        /*If the only key value is an auto-incremented integer,
+        * and the inserted value is null, then we can skip the selection phase.*/
+        status: if (canOptimizeInsertion == 0) {
+            Collection<Column<?>> pkColumns = meta().getPrimaryKey().values();
+            if (pkColumns.size() == 1) {
+                Column<?> pkColumn = pkColumns.iterator().next();
+                if (pkColumn instanceof IntegerColumn) {
+                    IntegerColumn intPkColumn = (IntegerColumn) pkColumn;
+                    canOptimizeInsertion = intPkColumn.getSequence() == null ? (byte) 1 : (byte) 2;
+                    break status;
+                }
+            }
+            canOptimizeInsertion = 1;
+        }
+        return canOptimizeInsertion == 2 && getCurrentKeyValues()[0] == null;
+    }
+
     /**
      * Performs an update of the cursor content in the DB, throwing an exception
      * in case if a record with such key fields is not found.
@@ -290,8 +311,7 @@ public abstract class Cursor extends BasicCursor implements InFilterSupport {
         preUpdate();
         PreparedStatement g = getHelper.prepareGet(recversion, _currentKeyValues());
         try {
-            ResultSet rs = g.executeQuery();
-            try {
+            try (ResultSet rs = g.executeQuery()) {
                 if (!rs.next()) {
                     return false;
                 }
@@ -302,8 +322,6 @@ public abstract class Cursor extends BasicCursor implements InFilterSupport {
                     // фигурной скобкой? (проблема совместной работы над базой)
                     xRec._parseResult(rs);
                 }
-            } finally {
-                rs.close();
             }
 
             Object[] values = _currentValues();
@@ -520,8 +538,7 @@ public abstract class Cursor extends BasicCursor implements InFilterSupport {
         }
 
         try {
-            ResultSet rs = stmt.executeQuery();
-            try {
+            try (ResultSet rs = stmt.executeQuery()) {
                 if (rs.next()) {
                     InputStream is = rs.getBinaryStream(1);
                     if (!(is == null || rs.wasNull())) {
@@ -538,8 +555,6 @@ public abstract class Cursor extends BasicCursor implements InFilterSupport {
                     // Записи не существует вовсе
                     result = new BLOB();
                 }
-            } finally {
-                rs.close();
             }
             stmt.close();
         } catch (SQLException | IOException e) {
@@ -571,7 +586,7 @@ public abstract class Cursor extends BasicCursor implements InFilterSupport {
      * @param column the text field
      * @return length of the text field or -1 (minus one) for TEXT fields.
      */
-   public final int getMaxStrLen(ColumnMeta<String> column) {
+    public final int getMaxStrLen(ColumnMeta<String> column) {
         final int undefinedMaxlength = -1;
         if (column instanceof StringColumn) {
             StringColumn sc = (StringColumn) column;

--- a/celesta-test/src/test/java/ru/curs/celesta/script/TestSimpleCases.java
+++ b/celesta-test/src/test/java/ru/curs/celesta/script/TestSimpleCases.java
@@ -10,6 +10,7 @@ import simpleCases.*;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -207,4 +208,16 @@ public class TestSimpleCases implements ScriptTest {
         assertTrue(values[1].getClass() == String.class);
     }
 
+
+    @TestTemplate
+    void test_autoincremental_insertion(CallContext context) {
+        GetDateForViewCursor tableCursor = new GetDateForViewCursor(context);
+        tableCursor.deleteAll();
+        for (int i = 0; i < 7; i++) {
+            tableCursor.clear();
+            tableCursor.setDate(new Date());
+            tableCursor.insert();
+        }
+        assertEquals(7, tableCursor.count());
+    }
 }

--- a/celesta-test/src/test/java/ru/curs/celesta/script/TestSimpleCases.java
+++ b/celesta-test/src/test/java/ru/curs/celesta/script/TestSimpleCases.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import ru.curs.celesta.CallContext;
+import ru.curs.celesta.CelestaException;
 import ru.curs.celesta.syscursors.LogCursor;
 import simpleCases.*;
 
@@ -219,5 +220,27 @@ public class TestSimpleCases implements ScriptTest {
             tableCursor.insert();
         }
         assertEquals(7, tableCursor.count());
+    }
+
+    @TestTemplate
+    void test_duplicate_insertion(CallContext context) {
+        DuplicateCursor c = new DuplicateCursor(context);
+        c.deleteAll();
+        c.setId(7);
+        c.insert();
+
+        String message = assertThrows(CelestaException.class, c::insert).getMessage();
+        assertEquals("Record duplicate [7] already exists", message);
+    }
+
+    @TestTemplate
+    void test_update_nonexistent(CallContext context) {
+        DuplicateCursor c = new DuplicateCursor(context);
+        c.deleteAll();
+        c.setId(42);
+        c.setVal(42);
+
+        String message = assertThrows(CelestaException.class, c::update).getMessage();
+        assertEquals("Record duplicate [42] does not exist.", message);
     }
 }


### PR DESCRIPTION
## Overview

Get rid of pre-selection of the rows when inserting into a table that relies on a sequence to generate its PK values.

---

### Checklist

- [X] Change is covered by automated tests.
- NA JavaDoc / User Guide is updated.
- [x] CI builds pass.
- [x] PR is tagged.
