### PR TITLE
Add typed parameters for parameterized views

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ There we discuss new major/compatibility breaking proposals before the implement
 
 Celesta is using [TestContainers](https://www.testcontainers.org/) for tests. If you want to build Celesta with test run, you will need Docker on your machine. Allow some time and network traffic to automatically download the Docker images with the Celesta-supported database engines.
 
-If you want to build `celesta-documentation` module locally, you will need to install [Graphviz](https://www.graphviz.org/) and [syntrax](https://github.com/kevinpt/syntrax). They are required to generate UML and syntax diagrams in the documentation.
+If you want to build `celesta-documentation` module locally, you will need to install [Graphviz](https://www.graphviz.org/) and [jsyntrax](https://github.com/atp-mipt/jsyntrax). They are required to generate UML and syntax diagrams in the documentation.
 
 ## Pull Request Check List
 

--- a/celesta-maven-plugin/src/main/java/ru/curs/celesta/plugin/maven/CursorGenerator.java
+++ b/celesta-maven-plugin/src/main/java/ru/curs/celesta/plugin/maven/CursorGenerator.java
@@ -401,8 +401,8 @@ public final class CursorGenerator {
                 ).build());
             }
 
-            String spec = "super (context, paramsMap(" +
-                    pv.getParameters().values().stream().map(c -> "$N").collect(Collectors.joining(", "))
+            String spec = "super (context, paramsMap("
+                    + pv.getParameters().values().stream().map(c -> "$N").collect(Collectors.joining(", "))
                     + "))";
             builder.addStatement(spec, pv.getParameters().keySet().toArray());
             results.add(builder.build());
@@ -414,8 +414,8 @@ public final class CursorGenerator {
                 ).build());
             }
             builder.addParameter(columnsParam).varargs();
-            spec = "super (context, paramsMap(" +
-                    pv.getParameters().values().stream().map(c -> "$N").collect(Collectors.joining(", "))
+            spec = "super (context, paramsMap("
+                    + pv.getParameters().values().stream().map(c -> "$N").collect(Collectors.joining(", "))
                     + "), columns)";
             builder.addStatement(spec, pv.getParameters().keySet().toArray());
             results.add(builder.build());
@@ -692,8 +692,8 @@ public final class CursorGenerator {
                 .addModifiers(Modifier.PROTECTED)
                 .addAnnotation(Override.class)
                 .returns(resultType);
-        String spec = "return new Object[] {" +
-                pk.stream().map(c -> "$N").collect(Collectors.joining(", "))
+        String spec = "return new Object[] {"
+                + pk.stream().map(c -> "$N").collect(Collectors.joining(", "))
                 + "}";
         builder.addStatement(spec, pk.stream()
                 .map(NamedElement::getName).toArray());
@@ -707,8 +707,8 @@ public final class CursorGenerator {
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(Override.class)
                 .returns(resultType);
-        String spec = "return new Object[] {" +
-                columns.values().stream().map(c -> "$N").collect(Collectors.joining(", "))
+        String spec = "return new Object[] {"
+                + columns.values().stream().map(c -> "$N").collect(Collectors.joining(", "))
                 + "}";
         builder.addStatement(spec, columns.values().stream()
                 .map(ColumnMeta::getName).toArray());

--- a/celesta-maven-plugin/src/main/java/ru/curs/celesta/plugin/maven/GenCursorsMojo.java
+++ b/celesta-maven-plugin/src/main/java/ru/curs/celesta/plugin/maven/GenCursorsMojo.java
@@ -1,6 +1,7 @@
 package ru.curs.celesta.plugin.maven;
 
-import org.apache.maven.plugins.annotations.*;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
 
 @Mojo(
         name = "gen-cursors",

--- a/celesta-maven-plugin/src/test/resources/gen-cursors/expectedGenerationResults/data/table/TestRoTableCursor.java
+++ b/celesta-maven-plugin/src/test/resources/gen-cursors/expectedGenerationResults/data/table/TestRoTableCursor.java
@@ -20,12 +20,12 @@ import ru.curs.celesta.score.ReadOnlyTable;
 
 @Generated(
         value = "ru.curs.celesta.plugin.maven.CursorGenerator",
-        date = "2020-02-25 10:50"
+        date = "2021-04-15T01:58:49.662"
 )
 @CelestaGenerated
 public final class TestRoTableCursor extends ReadOnlyTableCursor implements Iterable<TestRoTableCursor> {
-
     private static final String GRAIN_NAME = "test";
+
     private static final String OBJECT_NAME = "testRoTable";
 
     public final TestRoTableCursor.Columns COLUMNS;
@@ -63,7 +63,8 @@ public final class TestRoTableCursor extends ReadOnlyTableCursor implements Iter
             Field f = getClass().getDeclaredField(name);
             f.setAccessible(true);
             return f.get(this);
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -72,10 +73,10 @@ public final class TestRoTableCursor extends ReadOnlyTableCursor implements Iter
     protected void _setFieldValue(String name, Object value) {
         try {
             Field f = getClass().getDeclaredField(name);
-
             f.setAccessible(true);
             f.set(this, value);
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -97,18 +98,16 @@ public final class TestRoTableCursor extends ReadOnlyTableCursor implements Iter
 
     @Override
     public Object[] _currentValues() {
-        Object[] result = new Object[1];
-        result[0] = this.id;
-        return result;
+        return new Object[] {id};
     }
 
     @Override
     public TestRoTableCursor _getBufferCopy(CallContext context, List<String> fields) {
         final TestRoTableCursor result;
-
         if (Objects.isNull(fields)) {
             result = new TestRoTableCursor(context);
-        } else {
+        }
+        else {
             result = new TestRoTableCursor(context, new LinkedHashSet<>(fields));
         }
         result.copyFieldsFrom(this);
@@ -139,7 +138,7 @@ public final class TestRoTableCursor extends ReadOnlyTableCursor implements Iter
     @SuppressWarnings("unchecked")
     @Generated(
             value = "ru.curs.celesta.plugin.maven.CursorGenerator",
-            date = "2020-02-25T10:50:49"
+            date = "2021-04-15T01:58:49.664"
     )
     @CelestaGenerated
     public static final class Columns {
@@ -156,16 +155,16 @@ public final class TestRoTableCursor extends ReadOnlyTableCursor implements Iter
 
     @Generated(
             value = "ru.curs.celesta.plugin.maven.CursorGenerator",
-            date = "2020-02-25T10:50:49"
+            date = "2021-04-15T01:58:49.665"
     )
     @CelestaGenerated
     public static final class Id {
         public static final Integer open = 0;
+
         public static final Integer closed = 1;
 
         private Id() {
             throw new AssertionError();
         }
     }
-
 }

--- a/celesta-maven-plugin/src/test/resources/gen-cursors/expectedGenerationResults/data/table/TestTableCursor.java
+++ b/celesta-maven-plugin/src/test/resources/gen-cursors/expectedGenerationResults/data/table/TestTableCursor.java
@@ -17,7 +17,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.function.Consumer;
-
 import javax.annotation.Generated;
 import ru.curs.celesta.CallContext;
 import ru.curs.celesta.ICelesta;
@@ -32,24 +31,32 @@ import ru.curs.celesta.score.Table;
 
 @Generated(
         value = "ru.curs.celesta.plugin.maven.CursorGenerator",
-        date = "2020-02-25T10:50:49"
+        date = "2021-04-15T01:58:49.563"
 )
 @CelestaGenerated
 public final class TestTableCursor extends Cursor implements Iterable<TestTableCursor>, Serializable, Cloneable {
-
     private static final String GRAIN_NAME = "test";
+
     private static final String OBJECT_NAME = "testTable";
 
     public final TestTableCursor.Columns COLUMNS;
 
     private Integer id;
+
     private String str;
+
     private Boolean deleted;
+
     private Double weight;
+
     private String content;
+
     private Date created;
+
     private BLOB rawData;
+
     private BigDecimal cost;
+
     private ZonedDateTime toDelete;
 
     {
@@ -147,7 +154,8 @@ public final class TestTableCursor extends Cursor implements Iterable<TestTableC
             Field f = getClass().getDeclaredField(name);
             f.setAccessible(true);
             return f.get(this);
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -156,19 +164,17 @@ public final class TestTableCursor extends Cursor implements Iterable<TestTableC
     protected void _setFieldValue(String name, Object value) {
         try {
             Field f = getClass().getDeclaredField(name);
-
             f.setAccessible(true);
             f.set(this, value);
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
     @Override
     protected Object[] _currentKeyValues() {
-        Object[] result = new Object[1];
-        result[0] = this.id;
-        return result;
+        return new Object[] {id};
     }
 
     @Override
@@ -220,7 +226,8 @@ public final class TestTableCursor extends Cursor implements Iterable<TestTableC
             Timestamp ts = rs.getTimestamp("toDelete", Calendar.getInstance(TimeZone.getTimeZone("UTC")));
             if (ts != null) {
                 this.toDelete = ZonedDateTime.of(ts.toLocalDateTime(), ZoneOffset.systemDefault());
-            } else {
+            }
+            else {
                 this.toDelete = null;
             }
         }
@@ -244,17 +251,7 @@ public final class TestTableCursor extends Cursor implements Iterable<TestTableC
 
     @Override
     public Object[] _currentValues() {
-        Object[] result = new Object[9];
-        result[0] = this.id;
-        result[1] = this.str;
-        result[2] = this.deleted;
-        result[3] = this.weight;
-        result[4] = this.content;
-        result[5] = this.created;
-        result[6] = this.rawData;
-        result[7] = this.cost;
-        result[8] = this.toDelete;
-        return result;
+        return new Object[] {id, str, deleted, weight, content, created, rawData, cost, toDelete};
     }
 
     public void calcRawData() {
@@ -267,27 +264,33 @@ public final class TestTableCursor extends Cursor implements Iterable<TestTableC
         this.id = val;
     }
 
-    public static void onPreDelete(ICelesta celesta, Consumer<? super TestTableCursor> cursorConsumer) {
+    public static void onPreDelete(ICelesta celesta,
+            Consumer<? super TestTableCursor> cursorConsumer) {
         celesta.getTriggerDispatcher().registerTrigger(TriggerType.PRE_DELETE, TestTableCursor.class, cursorConsumer);
     }
 
-    public static void onPostDelete(ICelesta celesta, Consumer<? super TestTableCursor> cursorConsumer) {
+    public static void onPostDelete(ICelesta celesta,
+            Consumer<? super TestTableCursor> cursorConsumer) {
         celesta.getTriggerDispatcher().registerTrigger(TriggerType.POST_DELETE, TestTableCursor.class, cursorConsumer);
     }
 
-    public static void onPreInsert(ICelesta celesta, Consumer<? super TestTableCursor> cursorConsumer) {
+    public static void onPreInsert(ICelesta celesta,
+            Consumer<? super TestTableCursor> cursorConsumer) {
         celesta.getTriggerDispatcher().registerTrigger(TriggerType.PRE_INSERT, TestTableCursor.class, cursorConsumer);
     }
 
-    public static void onPostInsert(ICelesta celesta, Consumer<? super TestTableCursor> cursorConsumer) {
+    public static void onPostInsert(ICelesta celesta,
+            Consumer<? super TestTableCursor> cursorConsumer) {
         celesta.getTriggerDispatcher().registerTrigger(TriggerType.POST_INSERT, TestTableCursor.class, cursorConsumer);
     }
 
-    public static void onPreUpdate(ICelesta celesta, Consumer<? super TestTableCursor> cursorConsumer) {
+    public static void onPreUpdate(ICelesta celesta,
+            Consumer<? super TestTableCursor> cursorConsumer) {
         celesta.getTriggerDispatcher().registerTrigger(TriggerType.PRE_UPDATE, TestTableCursor.class, cursorConsumer);
     }
 
-    public static void onPostUpdate(ICelesta celesta, Consumer<? super TestTableCursor> cursorConsumer) {
+    public static void onPostUpdate(ICelesta celesta,
+            Consumer<? super TestTableCursor> cursorConsumer) {
         celesta.getTriggerDispatcher().registerTrigger(TriggerType.POST_UPDATE, TestTableCursor.class, cursorConsumer);
     }
 
@@ -296,7 +299,8 @@ public final class TestTableCursor extends Cursor implements Iterable<TestTableC
         final TestTableCursor result;
         if (Objects.isNull(fields)) {
             result = new TestTableCursor(context);
-        } else {
+        }
+        else {
             result = new TestTableCursor(context, new LinkedHashSet<>(fields));
         }
         result.copyFieldsFrom(this);
@@ -336,7 +340,7 @@ public final class TestTableCursor extends Cursor implements Iterable<TestTableC
     @SuppressWarnings("unchecked")
     @Generated(
             value = "ru.curs.celesta.plugin.maven.CursorGenerator",
-            date = "2020-02-25T10:50:49"
+            date = "2021-04-15T01:58:49.593"
     )
     @CelestaGenerated
     public static final class Columns {
@@ -381,12 +385,14 @@ public final class TestTableCursor extends Cursor implements Iterable<TestTableC
 
     @Generated(
             value = "ru.curs.celesta.plugin.maven.CursorGenerator",
-            date = "2020-02-25T10:50:49"
+            date = "2021-04-15T01:58:49.603"
     )
     @CelestaGenerated
     public static final class Str {
         public static final String one = "one";
+
         public static final String two = "two";
+
         public static final String three = "three";
 
         private Str() {

--- a/celesta-maven-plugin/src/test/resources/gen-cursors/expectedGenerationResults/data/view/TestTableMvCursor.java
+++ b/celesta-maven-plugin/src/test/resources/gen-cursors/expectedGenerationResults/data/view/TestTableMvCursor.java
@@ -21,18 +21,20 @@ import ru.curs.celesta.score.MaterializedView;
 
 @Generated(
         value = "ru.curs.celesta.plugin.maven.CursorGenerator",
-        date = "2020-02-25T10:50:49"
+        date = "2021-04-15T02:06:38.892"
 )
 @CelestaGenerated
 public final class TestTableMvCursor extends MaterializedViewCursor implements Iterable<TestTableMvCursor> {
-
     private static final String GRAIN_NAME = "test";
+
     private static final String OBJECT_NAME = "testTableMv";
 
     public final TestTableMvCursor.Columns COLUMNS;
 
     private Integer surrogate_count;
+
     private Integer c;
+
     private BigDecimal cost;
 
     {
@@ -80,10 +82,10 @@ public final class TestTableMvCursor extends MaterializedViewCursor implements I
     protected Object _getFieldValue(String name) {
         try {
             Field f = getClass().getDeclaredField(name);
-
             f.setAccessible(true);
             return f.get(this);
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -92,19 +94,17 @@ public final class TestTableMvCursor extends MaterializedViewCursor implements I
     protected void _setFieldValue(String name, Object value) {
         try {
             Field f = getClass().getDeclaredField(name);
-
             f.setAccessible(true);
             f.set(this, value);
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
     @Override
     protected Object[] _currentKeyValues() {
-        Object[] result = new Object[1];
-        result[0] = this.cost;
-        return result;
+        return new Object[] {cost};
     }
 
     @Override
@@ -140,20 +140,16 @@ public final class TestTableMvCursor extends MaterializedViewCursor implements I
 
     @Override
     public Object[] _currentValues() {
-        Object[] result = new Object[3];
-        result[0] = this.surrogate_count;
-        result[1] = this.c;
-        result[2] = this.cost;
-        return result;
+        return new Object[] {surrogate_count, c, cost};
     }
 
     @Override
     public TestTableMvCursor _getBufferCopy(CallContext context, List<String> fields) {
         final TestTableMvCursor result;
-
         if (Objects.isNull(fields)) {
             result = new TestTableMvCursor(context);
-        } else {
+        }
+        else {
             result = new TestTableMvCursor(context, new LinkedHashSet<>(fields));
         }
         result.copyFieldsFrom(this);
@@ -186,7 +182,7 @@ public final class TestTableMvCursor extends MaterializedViewCursor implements I
     @SuppressWarnings("unchecked")
     @Generated(
             value = "ru.curs.celesta.plugin.maven.CursorGenerator",
-            date = "2020-02-25T10:50:49"
+            date = "2021-04-15T02:06:38.893"
     )
     @CelestaGenerated
     public static final class Columns {
@@ -208,5 +204,4 @@ public final class TestTableMvCursor extends MaterializedViewCursor implements I
             return (ColumnMeta<BigDecimal>) this.element.getColumns().get("cost");
         }
     }
-
 }

--- a/celesta-maven-plugin/src/test/resources/gen-cursors/expectedGenerationResults/data/view/TestTablePvCursor.java
+++ b/celesta-maven-plugin/src/test/resources/gen-cursors/expectedGenerationResults/data/view/TestTablePvCursor.java
@@ -3,6 +3,7 @@ package data.view;
 import java.lang.reflect.Field;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -21,12 +22,12 @@ import ru.curs.celesta.score.ParameterizedView;
 
 @Generated(
         value = "ru.curs.celesta.plugin.maven.CursorGenerator",
-        date = "2020-02-25T10:50:49"
+        date = "2021-04-15T02:06:38.84"
 )
 @CelestaGenerated
 public final class TestTablePvCursor extends ParameterizedViewCursor implements Iterable<TestTablePvCursor> {
-
     private static final String GRAIN_NAME = "test";
+
     private static final String OBJECT_NAME = "testTablePv";
 
     public final TestTablePvCursor.Columns COLUMNS;
@@ -41,13 +42,29 @@ public final class TestTablePvCursor extends ParameterizedViewCursor implements 
         super(context, parameters);
     }
 
-    public TestTablePvCursor(CallContext context, Map<String, Object> parameters, ColumnMeta<?>... columns) {
+    public TestTablePvCursor(CallContext context, Map<String, Object> parameters,
+            ColumnMeta<?>... columns) {
         super(context, parameters, columns);
     }
 
     @Deprecated
-    public TestTablePvCursor(CallContext context, Set<String> fields, Map<String, Object> parameters) {
+    public TestTablePvCursor(CallContext context, Set<String> fields,
+            Map<String, Object> parameters) {
         super(context, fields, parameters);
+    }
+
+    public TestTablePvCursor(CallContext context, Integer p) {
+        super (context, paramsMap(p));
+    }
+
+    public TestTablePvCursor(CallContext context, Integer p, ColumnMeta<?>... columns) {
+        super (context, paramsMap(p), columns);
+    }
+
+    private static Map<String, Object> paramsMap(Integer p) {
+        Map<String,Object> params = new HashMap<>();
+        params.put("p", p);
+        return params;
     }
 
     public Integer getS() {
@@ -62,10 +79,10 @@ public final class TestTablePvCursor extends ParameterizedViewCursor implements 
     protected Object _getFieldValue(String name) {
         try {
             Field f = getClass().getDeclaredField(name);
-
             f.setAccessible(true);
             return f.get(this);
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -74,10 +91,10 @@ public final class TestTablePvCursor extends ParameterizedViewCursor implements 
     protected void _setFieldValue(String name, Object value) {
         try {
             Field f = getClass().getDeclaredField(name);
-
             f.setAccessible(true);
             f.set(this, value);
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -99,18 +116,16 @@ public final class TestTablePvCursor extends ParameterizedViewCursor implements 
 
     @Override
     public Object[] _currentValues() {
-        Object[] result = new Object[1];
-        result[0] = this.s;
-        return result;
+        return new Object[] {s};
     }
 
     @Override
     public TestTablePvCursor _getBufferCopy(CallContext context, List<String> fields) {
         final TestTablePvCursor result;
-
         if (Objects.isNull(fields)) {
             result = new TestTablePvCursor(context, this.parameters);
-        } else {
+        }
+        else {
             result = new TestTablePvCursor(context, new LinkedHashSet<>(fields), this.parameters);
         }
         result.copyFieldsFrom(this);
@@ -141,7 +156,7 @@ public final class TestTablePvCursor extends ParameterizedViewCursor implements 
     @SuppressWarnings("unchecked")
     @Generated(
             value = "ru.curs.celesta.plugin.maven.CursorGenerator",
-            date = "2020-02-25T10:50:49"
+            date = "2021-04-15T02:06:38.844"
     )
     @CelestaGenerated
     public static final class Columns {
@@ -155,5 +170,4 @@ public final class TestTablePvCursor extends ParameterizedViewCursor implements 
             return (ColumnMeta<Integer>) this.element.getColumns().get("s");
         }
     }
-
 }

--- a/celesta-maven-plugin/src/test/resources/gen-cursors/expectedGenerationResults/data/view/TestTableVCursor.java
+++ b/celesta-maven-plugin/src/test/resources/gen-cursors/expectedGenerationResults/data/view/TestTableVCursor.java
@@ -20,12 +20,12 @@ import ru.curs.celesta.score.View;
 
 @Generated(
         value = "ru.curs.celesta.plugin.maven.CursorGenerator",
-        date = "2020-02-25T10:50:49"
+        date = "2021-04-15T02:06:38.885"
 )
 @CelestaGenerated
 public final class TestTableVCursor extends ViewCursor implements Iterable<TestTableVCursor> {
-
     private static final String GRAIN_NAME = "test";
+
     private static final String OBJECT_NAME = "testTableV";
 
     public final TestTableVCursor.Columns COLUMNS;
@@ -61,10 +61,10 @@ public final class TestTableVCursor extends ViewCursor implements Iterable<TestT
     protected Object _getFieldValue(String name) {
         try {
             Field f = getClass().getDeclaredField(name);
-
             f.setAccessible(true);
             return f.get(this);
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -73,10 +73,10 @@ public final class TestTableVCursor extends ViewCursor implements Iterable<TestT
     protected void _setFieldValue(String name, Object value) {
         try {
             Field f = getClass().getDeclaredField(name);
-
             f.setAccessible(true);
             f.set(this, value);
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -98,18 +98,16 @@ public final class TestTableVCursor extends ViewCursor implements Iterable<TestT
 
     @Override
     public Object[] _currentValues() {
-        Object[] result = new Object[1];
-        result[0] = this.id;
-        return result;
+        return new Object[] {id};
     }
 
     @Override
     public TestTableVCursor _getBufferCopy(CallContext context, List<String> fields) {
         final TestTableVCursor result;
-
         if (Objects.isNull(fields)) {
             result = new TestTableVCursor(context);
-        } else {
+        }
+        else {
             result = new TestTableVCursor(context, new LinkedHashSet<>(fields));
         }
         result.copyFieldsFrom(this);
@@ -140,7 +138,7 @@ public final class TestTableVCursor extends ViewCursor implements Iterable<TestT
     @SuppressWarnings("unchecked")
     @Generated(
             value = "ru.curs.celesta.plugin.maven.CursorGenerator",
-            date = "2020-02-25T10:50:49"
+            date = "2021-04-15T02:06:38.886"
     )
     @CelestaGenerated
     public static final class Columns {
@@ -154,5 +152,4 @@ public final class TestTableVCursor extends ViewCursor implements Iterable<TestT
             return (ColumnMeta<Integer>) this.element.getColumns().get("id");
         }
     }
-
 }


### PR DESCRIPTION
Parameterized views, unlike what was promised in documentation, do not offer constructors with typed parameters (they accept `Map<String, Object>` instead). This PR adds these generated constructors to parameterized view cursor classes.

## Overview

Add generated constructors with typed parameters

---

### Checklist

- [x] Change is covered by automated tests.
- NA JavaDoc / User Guide is updated.
- [x] CI builds pass.
- [x] PR is tagged.
