### PR TITLE
CelestaUnit improvements

### DIFF
--- a/celesta-documentation/src/main/asciidoc/en/1130_celesta_unit.adoc
+++ b/celesta-documentation/src/main/asciidoc/en/1130_celesta_unit.adoc
@@ -48,6 +48,11 @@ public class DocumentServiceTest {
 
     DocumentService srv = new DocumentService();
 
+    @BeforeEach
+    void setUp(CallContext context) {
+        //Set up data needed for each test here
+    }
+
     @Test
     /*CallContext parameter will be injected automatically
     based on a temporary H2 database*/
@@ -64,6 +69,7 @@ public class DocumentServiceTest {
 
 This means every test can receive an active `CallContext` as a parameter.
 This context is generated based on H2 database, to which a Celesta score is deployed and can be used to create cursors.
+When `@BeforeEach`-annotated methods are used, the same `CallContext` will be provided in the setup method and test method.
 
 == Changing CelestaUnit Default Settings
 
@@ -71,7 +77,8 @@ CelestaUnit has the following defaults:
 
 * score path: `src/main/resources/score`;
 * reference integrity check (with foreign keys) is enabled;
-* table clearing after each test is enabled.
+* table clearing before each test is enabled;
+* sequence resetting before each test is enabled.
 
 Defaults can be changed by using a JUnit5 {apidocs}ru/curs/celestaunit/CelestaUnitExtension.html[`CelestaUnitExtension`] extension https://junit.org/junit5/docs/current/user-guide/#extensions-registration-programmatic[programmatic registration] in a test class:
 
@@ -83,7 +90,7 @@ public class DocumentServiceTest {
             CelestaUnitExtension.builder()
                     .withScorePath(SCORE_PATH)
                     .withReferentialIntegrity(true)
-                    .withTruncateAfterEach(false).build();
+                    .withTruncateTables(false).build();
 ```
 
 In some cases it might help to disable reference integrity check to simplify adding test data to tables linked by foreign keys to other tables.

--- a/celesta-documentation/src/main/asciidoc/en/1130_celesta_unit.adoc
+++ b/celesta-documentation/src/main/asciidoc/en/1130_celesta_unit.adoc
@@ -80,17 +80,15 @@ CelestaUnit has the following defaults:
 * table clearing before each test is enabled;
 * sequence resetting before each test is enabled.
 
-Defaults can be changed by using a JUnit5 {apidocs}ru/curs/celestaunit/CelestaUnitExtension.html[`CelestaUnitExtension`] extension https://junit.org/junit5/docs/current/user-guide/#extensions-registration-programmatic[programmatic registration] in a test class:
+Defaults can be changed by using {apidocs}ru/curs/celestaunit/CelestaTest.html[`@CelestaTest`] annotation parameters:
 
 ```java
+@CelestaTest(scorePath = DocumentServiceTest.SCORE_PATH,
+    referentialIntegrity = true,
+    truncateTables = false,
+    resetSequences = false)
 public class DocumentServiceTest {
     public static final String SCORE_PATH = "src/test/resources/score";
-    @RegisterExtension
-    static CelestaUnitExtension ext =
-            CelestaUnitExtension.builder()
-                    .withScorePath(SCORE_PATH)
-                    .withReferentialIntegrity(true)
-                    .withTruncateTables(false).build();
 ```
 
 In some cases it might help to disable reference integrity check to simplify adding test data to tables linked by foreign keys to other tables.

--- a/celesta-documentation/src/main/asciidoc/ru/1130_celesta_unit.adoc
+++ b/celesta-documentation/src/main/asciidoc/ru/1130_celesta_unit.adoc
@@ -49,6 +49,12 @@ public class DocumentServiceTest {
 
     DocumentService srv = new DocumentService();
 
+    @BeforeEach
+    void setUp(CallContext context) {
+        //Здесь можно наполнить базу данными, нужными для каждого теста
+    }
+
+
     @Test
     /*Параметр CallContext будет подставлен автоматически,
     на основе временной базы данных H2*/
@@ -65,6 +71,7 @@ public class DocumentServiceTest {
 
 Таким образом, каждый из тестов может получать в качестве параметра активный `CallContext`.
 Этот контекст формируется на основе базы данных H2, в которой развёрнута Celesta score, и может быть использован для создания курсоров.
+Если используются `@BeforeEach`-методы, вызываемые перед каждым тестом, то в них будет передаваться тот же `CallContext`, что и в тестовый метод.
 
 == Изменение настроек CelestaUnit по умолчанию
 
@@ -72,7 +79,8 @@ CelestaUnit работает со следующими умолчаниями:
 
 * Score path: `src/main/resources/score`.
 * Проверка ссылочной целостности (по Foreign keys) по умолчанию включена.
-* Очистка таблиц после каждого теста по умолчанию включена.
+* Очистка таблиц перед каждым тестом по умолчанию включена.
+* Сброс значений sequence-ов перед каждым тестом по умолчанию включен.
 
 Изменить умолчания можно, воспользовавшись в тестовом классе https://junit.org/junit5/docs/current/user-guide/#extensions-registration-programmatic[программной регистрацией] расширения {apidocs}ru/curs/celestaunit/CelestaUnitExtension.html[`CelestaUnitExtension`] в JUnit5:
 
@@ -84,7 +92,7 @@ public class DocumentServiceTest {
             CelestaUnitExtension.builder()
                     .withScorePath(SCORE_PATH)
                     .withReferentialIntegrity(true)
-                    .withTruncateAfterEach(false).build();
+                    .withTruncateTables(false).build();
 ```
 
 Например, в ряде случаев бывает полезно отключить проверку ссылочной целостности, что упрощает добавление тестовых данных в таблицы, связанные внешними ключами с другими таблицами.

--- a/celesta-documentation/src/main/asciidoc/ru/1130_celesta_unit.adoc
+++ b/celesta-documentation/src/main/asciidoc/ru/1130_celesta_unit.adoc
@@ -82,17 +82,15 @@ CelestaUnit работает со следующими умолчаниями:
 * Очистка таблиц перед каждым тестом по умолчанию включена.
 * Сброс значений sequence-ов перед каждым тестом по умолчанию включен.
 
-Изменить умолчания можно, воспользовавшись в тестовом классе https://junit.org/junit5/docs/current/user-guide/#extensions-registration-programmatic[программной регистрацией] расширения {apidocs}ru/curs/celestaunit/CelestaUnitExtension.html[`CelestaUnitExtension`] в JUnit5:
+Изменить умолчания можно, воспользовавшись параметрами аннотации {apidocs}ru/curs/celestaunit/CelestaTest.html[`@CelestaTest`]:
 
 ```java
+@CelestaTest(scorePath = DocumentServiceTest.SCORE_PATH,
+    referentialIntegrity = true,
+    truncateTables = false,
+    resetSequences = false)
 public class DocumentServiceTest {
     public static final String SCORE_PATH = "src/test/resources/score";
-    @RegisterExtension
-    static CelestaUnitExtension ext =
-            CelestaUnitExtension.builder()
-                    .withScorePath(SCORE_PATH)
-                    .withReferentialIntegrity(true)
-                    .withTruncateTables(false).build();
 ```
 
 Например, в ряде случаев бывает полезно отключить проверку ссылочной целостности, что упрощает добавление тестовых данных в таблицы, связанные внешними ключами с другими таблицами.

--- a/celesta-unit/src/main/celestasql/s1/s1.sql
+++ b/celesta-unit/src/main/celestasql/s1/s1.sql
@@ -9,3 +9,5 @@ create table line (
   header_id int not null foreign key references header(id),
   CONSTRAINT pk_line PRIMARY KEY (id, header_id)
 );
+
+create sequence seq1;

--- a/celesta-unit/src/main/java/ru/curs/celestaunit/CelestaTest.java
+++ b/celesta-unit/src/main/java/ru/curs/celestaunit/CelestaTest.java
@@ -8,11 +8,29 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Shortcut annotation for extending tests with CelestaUnitExtension,
- * using default parameters.
+ * Annotation for extending tests with CelestaUnitExtension.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @ExtendWith(CelestaUnitExtension.class)
 public @interface CelestaTest {
+    /**
+     * Sets score path (maybe relative to project root).
+     */
+    String scorePath() default "";
+
+    /**
+     * Sets referential integrity (set to false to disable).
+     */
+    boolean referentialIntegrity() default true;
+
+    /**
+     * Sets tables truncation before each test.
+     */
+    boolean truncateTables() default true;
+
+    /**
+     * Resets sequences before each test.
+     */
+    boolean resetSequences() default true;
 }

--- a/celesta-unit/src/main/java/ru/curs/celestaunit/CelestaUnitExtension.java
+++ b/celesta-unit/src/main/java/ru/curs/celestaunit/CelestaUnitExtension.java
@@ -1,7 +1,13 @@
 package ru.curs.celestaunit;
 
-import org.junit.jupiter.api.extension.*;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
 import ru.curs.celesta.CallContext;
 import ru.curs.celesta.Celesta;
 import ru.curs.celesta.CelestaException;
@@ -162,7 +168,8 @@ public final class CelestaUnitExtension implements BeforeAllCallback,
              Statement stmt = conn.createStatement()) {
             for (Grain grain : celesta.getScore().getGrains().values()) {
                 for (String seqName : grain.getElements(SequenceElement.class).keySet()) {
-                    stmt.execute(String.format("ALTER SEQUENCE \"%s\".\"%s\" RESTART WITH 1", grain.getName(), seqName));
+                    stmt.execute(String.format("ALTER SEQUENCE \"%s\".\"%s\" RESTART WITH 1",
+                            grain.getName(), seqName));
                     conn.commit();
                 }
             }

--- a/celesta-unit/src/main/java/ru/curs/celestaunit/CelestaUnitExtension.java
+++ b/celesta-unit/src/main/java/ru/curs/celestaunit/CelestaUnitExtension.java
@@ -221,7 +221,7 @@ public final class CelestaUnitExtension implements BeforeAllCallback,
         boolean isResetSequences(ExtensionContext extensionContext) {
             CelestaTest annotation = extensionContext.getRequiredTestClass().getAnnotation(CelestaTest.class);
             if (annotation != null) {
-                return annotation.truncateTables();
+                return annotation.resetSequences();
             } else {
                 return resetSequences;
             }

--- a/celesta-unit/src/main/java/ru/curs/celestaunit/CelestaUnitExtension.java
+++ b/celesta-unit/src/main/java/ru/curs/celestaunit/CelestaUnitExtension.java
@@ -100,10 +100,9 @@ public final class CelestaUnitExtension implements BeforeAllCallback,
 
     @Override
     public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
-        CallContext ctx = new SystemCallContext(celesta, extensionContext.getDisplayName());
-        extensionContext.getStore(namespace)
-                .put(extensionContext.getUniqueId(), ctx);
-        return ctx;
+        return extensionContext.getStore(namespace)
+                .getOrComputeIfAbsent(extensionContext.getUniqueId(),
+                        k -> new SystemCallContext(celesta, extensionContext.getDisplayName()), CallContext.class);
     }
 
     @Override

--- a/celesta-unit/src/test/java/ru/curs/celestaunit/BeforeEachContextTest.java
+++ b/celesta-unit/src/test/java/ru/curs/celestaunit/BeforeEachContextTest.java
@@ -1,0 +1,25 @@
+package ru.curs.celestaunit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import ru.curs.celesta.CallContext;
+import s1.HeaderCursor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@CelestaTest
+public class BeforeEachContextTest {
+    @BeforeEach
+    void fillTables(CallContext ctx) {
+        System.out.println("BEFORE EACH IN TEST");
+        HeaderCursor hc = new HeaderCursor(ctx);
+        hc.setId(100);
+        hc.insert();
+    }
+
+    @Test
+    void foo(CallContext ctx){
+        HeaderCursor hc = new HeaderCursor(ctx);
+        assertEquals(1, hc.count());
+    }
+}

--- a/celesta-unit/src/test/java/ru/curs/celestaunit/CelestaUnitExtensionNoTruncationNoIntegrityTest.java
+++ b/celesta-unit/src/test/java/ru/curs/celestaunit/CelestaUnitExtensionNoTruncationNoIntegrityTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import ru.curs.celesta.CallContext;
 import s1.HeaderCursor;
 import s1.LineCursor;
+import s1.Seq1Sequence;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -15,13 +16,15 @@ public class CelestaUnitExtensionNoTruncationNoIntegrityTest {
     @RegisterExtension
     static CelestaUnitExtension ext = CelestaUnitExtension.builder()
                     .withReferentialIntegrity(false)
-                    .withTruncateAfterEach(false)
+                    .withTruncateTables(false)
+                    .withResetSequences(false)
                     .build();
 
     @Test
     void extensionInitializedWithCorrectValues() {
         assertFalse(ext.isReferentialIntegrity());
-        assertFalse(ext.isTruncateAfterEach());
+        assertFalse(ext.isTruncateTables());
+        assertFalse(ext.isResetSequences());
     }
 
     @Test
@@ -50,4 +53,18 @@ public class CelestaUnitExtensionNoTruncationNoIntegrityTest {
         }
     }
 
+    @Test
+    @DisplayName("When resetSequences is on, and you get a value from sequence...")
+    public void sequencesReset1(CallContext ctx){
+        Seq1Sequence sequence = new Seq1Sequence(ctx);
+        assertEquals(1, sequence.nextValue());
+    }
+
+
+    @Test
+    @DisplayName("...this value persists in the following test")
+    public void sequencesReset2(CallContext ctx){
+        Seq1Sequence sequence = new Seq1Sequence(ctx);
+        assertEquals(2, sequence.nextValue());
+    }
 }

--- a/celesta-unit/src/test/java/ru/curs/celestaunit/CelestaUnitExtensionNoTruncationNoIntegrityTest.java
+++ b/celesta-unit/src/test/java/ru/curs/celestaunit/CelestaUnitExtensionNoTruncationNoIntegrityTest.java
@@ -8,8 +8,8 @@ import s1.HeaderCursor;
 import s1.LineCursor;
 import s1.Seq1Sequence;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CelestaUnitExtensionNoTruncationNoIntegrityTest {
 
@@ -22,9 +22,10 @@ public class CelestaUnitExtensionNoTruncationNoIntegrityTest {
 
     @Test
     void extensionInitializedWithCorrectValues() {
-        assertFalse(ext.isReferentialIntegrity());
-        assertFalse(ext.isTruncateTables());
-        assertFalse(ext.isResetSequences());
+        CelestaUnitExtension.Parameters extParameters = ext.getParameters();
+        assertFalse(extParameters.referentialIntegrity);
+        assertFalse(extParameters.truncateTables);
+        assertFalse(extParameters.resetSequences);
     }
 
     @Test

--- a/celesta-unit/src/test/java/ru/curs/celestaunit/CelestaUnitExtensionTest.java
+++ b/celesta-unit/src/test/java/ru/curs/celestaunit/CelestaUnitExtensionTest.java
@@ -7,6 +7,7 @@ import ru.curs.celesta.CallContext;
 import ru.curs.celesta.CelestaException;
 import s1.HeaderCursor;
 import s1.LineCursor;
+import s1.Seq1Sequence;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -20,7 +21,8 @@ public class CelestaUnitExtensionTest {
     @Test
     public void extensionInitializedWithCorrectValues() {
         assertTrue(ext.isReferentialIntegrity());
-        assertTrue(ext.isTruncateAfterEach());
+        assertTrue(ext.isTruncateTables());
+        assertTrue(ext.isResetSequences());
     }
 
     @Test
@@ -28,7 +30,8 @@ public class CelestaUnitExtensionTest {
         CelestaUnitExtension ext = new CelestaUnitExtension();
         assertEquals(CelestaUnitExtension.DEFAULT_SCORE, ext.getScorePath());
         assertTrue(ext.isReferentialIntegrity());
-        assertTrue(ext.isTruncateAfterEach());
+        assertTrue(ext.isTruncateTables());
+        assertTrue(ext.isResetSequences());
     }
 
     @Test
@@ -45,7 +48,7 @@ public class CelestaUnitExtensionTest {
     }
 
     @Test
-    @DisplayName("When truncateAfterEach is on, and you fill the tables in a test...")
+    @DisplayName("When truncateTables is on, and you fill the tables in a test...")
     public void tablesTruncated1(CallContext ctx) {
         fillTwoTables(ctx);
     }
@@ -59,6 +62,21 @@ public class CelestaUnitExtensionTest {
             assertEquals(0, hc.count());
             assertEquals(0, lc.count());
         }
+    }
+
+    @Test
+    @DisplayName("When resetSequences is on, and you get a value from sequence...")
+    public void sequencesReset1(CallContext ctx){
+        Seq1Sequence sequence = new Seq1Sequence(ctx);
+        assertEquals(1, sequence.nextValue());
+    }
+
+
+    @Test
+    @DisplayName("...this value resets in the following test")
+    public void sequencesReset2(CallContext ctx){
+        Seq1Sequence sequence = new Seq1Sequence(ctx);
+        assertEquals(1, sequence.nextValue());
     }
 
     public static void fillTwoTables(CallContext ctx) {

--- a/celesta-unit/src/test/java/ru/curs/celestaunit/CelestaUnitExtensionTest.java
+++ b/celesta-unit/src/test/java/ru/curs/celestaunit/CelestaUnitExtensionTest.java
@@ -20,18 +20,20 @@ public class CelestaUnitExtensionTest {
 
     @Test
     public void extensionInitializedWithCorrectValues() {
-        assertTrue(ext.isReferentialIntegrity());
-        assertTrue(ext.isTruncateTables());
-        assertTrue(ext.isResetSequences());
+        CelestaUnitExtension.Parameters extParameters = ext.getParameters();
+        assertTrue(extParameters.referentialIntegrity);
+        assertTrue(extParameters.truncateTables);
+        assertTrue(extParameters.resetSequences);
     }
 
     @Test
     public void defaultValuesAreCorrect() {
         CelestaUnitExtension ext = new CelestaUnitExtension();
-        assertEquals(CelestaUnitExtension.DEFAULT_SCORE, ext.getScorePath());
-        assertTrue(ext.isReferentialIntegrity());
-        assertTrue(ext.isTruncateTables());
-        assertTrue(ext.isResetSequences());
+        CelestaUnitExtension.Parameters extParameters = ext.getParameters();
+        assertEquals(CelestaUnitExtension.DEFAULT_SCORE, extParameters.scorePath);
+        assertTrue(extParameters.referentialIntegrity);
+        assertTrue(extParameters.truncateTables);
+        assertTrue(extParameters.resetSequences);
     }
 
     @Test

--- a/dict-en
+++ b/dict-en
@@ -387,3 +387,9 @@ instantiation
 PWD
 sqlserver
 tryGetCurrent
+BeforeEach
+referentialIntegrity
+resetSequences
+scorePath
+setUp
+truncateTables

--- a/dict-ru
+++ b/dict-ru
@@ -1234,3 +1234,9 @@ en
 Pool
 синглетоне
 tryGetCurrent
+BeforeEach
+referentialIntegrity
+resetSequences
+scorePath
+setUp
+truncateTables

--- a/dict-ru
+++ b/dict-ru
@@ -1240,3 +1240,4 @@ resetSequences
 scorePath
 setUp
 truncateTables
+ов


### PR DESCRIPTION
## Overview

1. Clean up before each test, not after each test.
2. Reset sequences.
3. Reuse CallContext from `@BeforeEach` call.
4. Parameterized `@CelestaTest` annotation.

---

### Checklist

- [X] Change is covered by automated tests.
- [X] JavaDoc / User Guide is updated.
- [x] CI builds pass.
- [X] PR is tagged.
