### PR TITLE
fix H2 materialized view bug

### DIFF
--- a/celesta-test/score/mView/_mView.sql
+++ b/celesta-test/score/mView/_mView.sql
@@ -61,6 +61,12 @@ create materialized view mView5 AS
   from table4
   group by var1, vvv;
 
+create materialized view mViewReverseOrder AS
+select var2, var1, sum(numb) as s
+    from table4
+group by var2, var1;
+
+
 CREATE SEQUENCE table5Num;
 
 create table table5 (

--- a/celesta-test/src/test/java/ru/curs/celesta/script/TestMaterializedView.java
+++ b/celesta-test/src/test/java/ru/curs/celesta/script/TestMaterializedView.java
@@ -1,6 +1,7 @@
 package ru.curs.celesta.script;
 
 import mView.*;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestTemplate;
 import ru.curs.celesta.CallContext;
 
@@ -414,4 +415,14 @@ public class TestMaterializedView implements ScriptTest {
         assertEquals(1, mViewCursor.count());
     }
 
+    @TestTemplate
+    void test_mat_view_reverse_order_of_columns(CallContext ctx) {
+        Table4Cursor t4 = new Table4Cursor(ctx);
+        t4.setVar1("v1").setVar2("v2").setNumb(1).insert();
+        t4.clear();
+        t4.setVar1("v1").setVar2("v2").setNumb(2).insert();
+        MViewReverseOrderCursor reverseOrderCursor = new MViewReverseOrderCursor(ctx);
+        reverseOrderCursor.get("v2", "v1");
+        assertEquals(3, reverseOrderCursor.getS());
+    }
 }

--- a/celesta-test/src/test/java/ru/curs/celesta/script/TestMaterializedView.java
+++ b/celesta-test/src/test/java/ru/curs/celesta/script/TestMaterializedView.java
@@ -1,7 +1,17 @@
 package ru.curs.celesta.script;
 
-import mView.*;
-import org.junit.jupiter.api.Test;
+import mView.MView1Cursor;
+import mView.MView2Cursor;
+import mView.MView3Cursor;
+import mView.MView4Cursor;
+import mView.MView5Cursor;
+import mView.MView6Cursor;
+import mView.MViewReverseOrderCursor;
+import mView.Table1Cursor;
+import mView.Table2Cursor;
+import mView.Table3Cursor;
+import mView.Table4Cursor;
+import mView.Table5Cursor;
 import org.junit.jupiter.api.TestTemplate;
 import ru.curs.celesta.CallContext;
 
@@ -65,21 +75,24 @@ public class TestMaterializedView implements ScriptTest {
         Table4Cursor tableCursor = new Table4Cursor(context);
         MView5Cursor mViewCursor = new MView5Cursor(context);
         assertEquals(0, mViewCursor.count());
-        tableCursor.setVar1("A");
-        tableCursor.setVar2("B");
-        tableCursor.setNumb(3);
-        tableCursor.insert();
-        tableCursor.setId(null);
-        tableCursor.setNumb(2);
-        tableCursor.insert();
+        tableCursor
+                .setVar1("A")
+                .setVar2("B")
+                .setNumb(3)
+                .insert();
+        tableCursor
+                .setId(null)
+                .setNumb(2)
+                .insert();
         assertEquals(1, mViewCursor.count());
         mViewCursor.get("A", "B");
         assertEquals(5, mViewCursor.getS().intValue());
 
-        tableCursor.setId(null);
-        tableCursor.setVar2("C");
-        tableCursor.setNumb(4);
-        tableCursor.insert();
+        tableCursor
+                .setId(null)
+                .setVar2("C")
+                .setNumb(4)
+                .insert();
         mViewCursor.get("A", "C");
         assertEquals(4, mViewCursor.getS().intValue());
         mViewCursor.tryGetCurrent();
@@ -97,15 +110,17 @@ public class TestMaterializedView implements ScriptTest {
         tableCursor.deleteAll();
         assertEquals(0, mViewCursor.count());
 
-        tableCursor.setNumb(5);
-        tableCursor.setVar("A");
-        tableCursor.insert();
+        tableCursor
+                .setNumb(5)
+                .setVar("A")
+                .insert();
         Integer id1 = tableCursor.getId();
         tableCursor.clear();
 
-        tableCursor.setNumb(2);
-        tableCursor.setVar("A");
-        tableCursor.insert();
+        tableCursor
+                .setNumb(2)
+                .setVar("A")
+                .insert();
         tableCursor.clear();
 
         mViewCursor.get("A");
@@ -113,24 +128,27 @@ public class TestMaterializedView implements ScriptTest {
 
         tableCursor.setRange(tableCursor.COLUMNS.numb(), 2);
         tableCursor.first();
-        tableCursor.setNumb(-5);
-        tableCursor.update();
+        tableCursor
+                .setNumb(-5)
+                .update();
         tableCursor.clear();
 
         mViewCursor.get("A");
         assertEquals(0, mViewCursor.getS().intValue());
 
-        tableCursor.setNumb(5);
-        tableCursor.setVar("A");
-        tableCursor.insert();
+        tableCursor
+                .setNumb(5)
+                .setVar("A")
+                .insert();
         tableCursor.clear();
 
         mViewCursor.get("A");
         assertEquals(5, mViewCursor.getS().intValue());
 
         tableCursor.get(id1);
-        tableCursor.setVar("B");
-        tableCursor.update();
+        tableCursor
+                .setVar("B")
+                .update();
         tableCursor.clear();
 
         mViewCursor.get("A");
@@ -150,22 +168,25 @@ public class TestMaterializedView implements ScriptTest {
         LocalDateTime datetime1 = LocalDateTime.of(2000, Month.AUGUST, 5, 10, 5, 32);
         LocalDateTime date1 = datetime1.truncatedTo(ChronoUnit.DAYS);
 
-        tableCursor.setNumb(5);
-        tableCursor.setDate(Timestamp.valueOf(datetime1));
-        tableCursor.insert();
+        tableCursor
+                .setNumb(5)
+                .setDate(Timestamp.valueOf(datetime1))
+                .insert();
         tableCursor.clear();
 
         LocalDateTime datetime2 = LocalDateTime.of(2000, Month.AUGUST, 5, 22, 5, 32);
-        tableCursor.setNumb(2);
-        tableCursor.setDate(Timestamp.valueOf(datetime2));
-        tableCursor.insert();
+        tableCursor
+                .setNumb(2)
+                .setDate(Timestamp.valueOf(datetime2))
+                .insert();
         tableCursor.clear();
 
         LocalDateTime datetime3 = LocalDateTime.of(2000, Month.AUGUST, 6, 10, 5, 32);
         LocalDateTime date2 = datetime3.truncatedTo(ChronoUnit.DAYS);
-        tableCursor.setNumb(5);
-        tableCursor.setDate(Timestamp.valueOf(datetime3));
-        tableCursor.insert();
+        tableCursor
+                .setNumb(5)
+                .setDate(Timestamp.valueOf(datetime3))
+                .insert();
         tableCursor.clear();
 
         assertEquals(2, mViewCursor.count());


### PR DESCRIPTION
## Overview

In H2, when order of `group by` fields in materialized view is different from the order of the corresponding fields in the source table, `primary key violation` occurs on the source table insertion.

Steps to reproduce:

```sql
create table table4 (
  id int not null default nextval(table4_id) primary key,
  var1 VARCHAR (2) not null,
  var2 VARCHAR (2) not null,
  numb int
);


create materialized view mViewReverseOrder AS
select var2, var1, sum(numb) as s
    from table4
group by var2, var1;

```

```java
Table4Cursor t4 = new Table4Cursor(ctx);
t4.setVar1("v1").setVar2("v2").setNumb(1).insert();
t4.clear();
t4.setVar1("v1").setVar2("v2").setNumb(2)
//exception here
.insert();
```
---

### Checklist

- [x] Change is covered by automated tests.
- [ ] JavaDoc / User Guide is updated.
- [x] CI builds pass.
- [x] PR is tagged.
