### PR TITLE
dont throw ParseException when using inFilter

### DIFF
--- a/celesta-core/src/main/java/ru/curs/celesta/dbutils/filter/value/FieldsLookup.java
+++ b/celesta-core/src/main/java/ru/curs/celesta/dbutils/filter/value/FieldsLookup.java
@@ -36,8 +36,8 @@ public final class FieldsLookup {
 
     private BasicCursor cursor;
     private BasicCursor otherCursor;
-    private Runnable lookupChangeCallback;
-    private Function<FieldsLookup, Void> newLookupCallback;
+    private final Runnable lookupChangeCallback;
+    private final Function<FieldsLookup, Void> newLookupCallback;
 
     public FieldsLookup(Cursor cursor, BasicCursor otherCursor,
                         Runnable lookupChangeCallback,
@@ -171,11 +171,14 @@ public final class FieldsLookup {
      * @param field      filed of the target cursor.
      * @param otherField field of the auxiliary cursor.
      * @return
-     * @throws ParseException if some column is not found.
      */
     @Deprecated
-    public FieldsLookup add(String field, String otherField) throws ParseException {
-        return internalAdd(validateFilteredColumn(field), validateFilteringColumn(otherField));
+    public FieldsLookup add(String field, String otherField) {
+        try {
+            return internalAdd(validateFilteredColumn(field), validateFilteringColumn(otherField));
+        } catch (ParseException e) {
+            throw new CelestaException(e.getMessage(), e);
+        }
     }
 
     /**
@@ -185,10 +188,13 @@ public final class FieldsLookup {
      * @param otherColumn column of the auxiliary cursor.
      * @param <T>         type of the column. Only columns of the same type can be bound in one filter.
      * @return
-     * @throws ParseException if a column is not found in the relevant table.
      */
-    public <T> FieldsLookup add(ColumnMeta<T> column, ColumnMeta<T> otherColumn) throws ParseException {
-        return internalAdd(column, otherColumn);
+    public <T> FieldsLookup add(ColumnMeta<T> column, ColumnMeta<T> otherColumn) {
+        try {
+            return internalAdd(column, otherColumn);
+        } catch (ParseException e) {
+            throw new CelestaException(e.getMessage(), e);
+        }
     }
 
     private FieldsLookup internalAdd(final ColumnMeta<?> column, final ColumnMeta<?> otherColumn) throws ParseException {

--- a/celesta-test/src/test/java/ru/curs/celesta/score/FieldsLookupTest.java
+++ b/celesta-test/src/test/java/ru/curs/celesta/score/FieldsLookupTest.java
@@ -91,28 +91,28 @@ public class FieldsLookupTest {
     @Test
     public void testAddWhenLeftColumnDoesNotExist() throws Exception {
         final FieldsLookup lookup = new FieldsLookup(tableA, tableB, lookupChangeCallback, newLookupCallback);
-        assertThrows(ParseException.class, () -> lookup.add("notExistedField", "b1"));
+        assertThrows(CelestaException.class, () -> lookup.add("notExistedField", "b1"));
 
         final FieldsLookup lookup2 = new FieldsLookup(viewA, viewB, lookupChangeCallback, newLookupCallback);
-        assertThrows(ParseException.class, () -> lookup2.add("notExistedField", "b1"));
+        assertThrows(CelestaException.class, () -> lookup2.add("notExistedField", "b1"));
     }
 
     @Test
     public void testAddWhenRightColumnDoesNotExist() throws Exception {
         final FieldsLookup lookup = new FieldsLookup(tableA, tableB, lookupChangeCallback, newLookupCallback);
-        assertThrows(ParseException.class, () -> lookup.add("a1", "notExistedField"));
+        assertThrows(CelestaException.class, () -> lookup.add("a1", "notExistedField"));
 
         final FieldsLookup lookup2 = new FieldsLookup(viewA, viewB, lookupChangeCallback, newLookupCallback);
-        assertThrows(ParseException.class, () -> lookup2.add("a1", "notExistedField"));
+        assertThrows(CelestaException.class, () -> lookup2.add("a1", "notExistedField"));
     }
 
     @Test
     public void testAddWhenBothColumnsDoNotExist() throws Exception {
         FieldsLookup lookup = new FieldsLookup(tableA, tableB, lookupChangeCallback, newLookupCallback);
-        assertThrows(ParseException.class, () -> lookup.add("notExistedField", "notExistedField"));
+        assertThrows(CelestaException.class, () -> lookup.add("notExistedField", "notExistedField"));
 
         FieldsLookup lookup2 = new FieldsLookup(viewA, viewB, lookupChangeCallback, newLookupCallback);
-        assertThrows(ParseException.class, () -> lookup2.add("notExistedField", "notExistedField"));
+        assertThrows(CelestaException.class, () -> lookup2.add("notExistedField", "notExistedField"));
     }
 
     @Test

--- a/celesta-test/src/test/java/ru/curs/celesta/script/TestFilter.java
+++ b/celesta-test/src/test/java/ru/curs/celesta/script/TestFilter.java
@@ -7,7 +7,6 @@ import ru.curs.celesta.CelestaException;
 import ru.curs.celesta.dbutils.BasicCursor;
 import ru.curs.celesta.dbutils.InFilterSupport;
 import ru.curs.celesta.dbutils.filter.value.FieldsLookup;
-import ru.curs.celesta.score.ParseException;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
@@ -544,11 +543,11 @@ public class TestFilter implements ScriptTest {
 
     void _testExceptionWhileAddingNotExistedFieldsToLookup(InFilterSupport a, BasicCursor b) {
         FieldsLookup lookup = a.setIn(b);
-        assertThrows(ParseException.class,
+        assertThrows(CelestaException.class,
                 () -> lookup.add("notExistingField", "created"));
-        assertThrows(ParseException.class,
+        assertThrows(CelestaException.class,
                 () -> lookup.add("date", "notExistingField"));
-        assertThrows(ParseException.class,
+        assertThrows(CelestaException.class,
                 () -> lookup.add("notExistingField", "notExistingField"));
     }
 

--- a/celesta-test/src/test/java/ru/curs/celesta/script/TestFilter.java
+++ b/celesta-test/src/test/java/ru/curs/celesta/script/TestFilter.java
@@ -19,35 +19,35 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class TestFilter implements ScriptTest {
 
     @TestTemplate
-    public void testInFilterForTable(CallContext context) throws ParseException {
+    public void testInFilterForTable(CallContext context) {
         AFilterCursor a = new AFilterCursor(context);
         BFilterCursor b = new BFilterCursor(context);
         _testInFilterForIndices(context, a, b);
     }
 
     @TestTemplate
-    public void testInFilterForView(CallContext context) throws ParseException {
+    public void testInFilterForView(CallContext context) {
         AFilterViewCursor a = new AFilterViewCursor(context);
         BFilterViewCursor b = new BFilterViewCursor(context);
         _testInFilterForIndices(context, a, b);
     }
 
     @TestTemplate
-    public void testInFilterForTableToView(CallContext context) throws ParseException {
+    public void testInFilterForTableToView(CallContext context) {
         AFilterCursor a = new AFilterCursor(context);
         BFilterViewCursor b = new BFilterViewCursor(context);
         _testInFilterForIndices(context, a, b);
     }
 
     @TestTemplate
-    public void testInFilterForViewToTable(CallContext context) throws ParseException {
+    public void testInFilterForViewToTable(CallContext context) {
         AFilterCursor a = new AFilterCursor(context);
         BFilterViewCursor b = new BFilterViewCursor(context);
         _testInFilterForIndices(context, a, b);
     }
 
     @TestTemplate
-    public void testInFilterForSimplePks(CallContext context) throws ParseException {
+    public void testInFilterForSimplePks(CallContext context) {
         CFilterCursor c = new CFilterCursor(context);
         DFilterCursor d = new DFilterCursor(context);
 
@@ -79,7 +79,7 @@ public class TestFilter implements ScriptTest {
     }
 
     @TestTemplate
-    public void testInFilterForComplexPks(CallContext context) throws ParseException {
+    public void testInFilterForComplexPks(CallContext context) {
         EFilterCursor e = new EFilterCursor(context);
         FFilterCursor f = new FFilterCursor(context);
 
@@ -114,21 +114,21 @@ public class TestFilter implements ScriptTest {
     }
 
     @TestTemplate
-    public void testInFilterWithRangeInMainCursorForTable(CallContext context) throws ParseException {
+    public void testInFilterWithRangeInMainCursorForTable(CallContext context) {
         AFilterCursor a = new AFilterCursor(context);
         BFilterCursor b = new BFilterCursor(context);
         _testInFilterWithRangeInMainCursor(context, a, b);
     }
 
     @TestTemplate
-    public void testInFilterWithRangeInMainCursorForView(CallContext context) throws ParseException {
+    public void testInFilterWithRangeInMainCursorForView(CallContext context) {
         AFilterViewCursor a = new AFilterViewCursor(context);
         BFilterViewCursor b = new BFilterViewCursor(context);
         _testInFilterWithRangeInMainCursor(context, a, b);
     }
 
     @TestTemplate
-    public void testInFilterWithRangeInMainCursorForTableToView(CallContext context) throws ParseException {
+    public void testInFilterWithRangeInMainCursorForTableToView(CallContext context) {
         AFilterCursor a = new AFilterCursor(context);
         BFilterViewCursor b = new BFilterViewCursor(context);
         _testInFilterWithRangeInMainCursor(context, a, b);
@@ -136,42 +136,42 @@ public class TestFilter implements ScriptTest {
 
 
     @TestTemplate
-    public void testInFilterWithRangeInOtherCursorBeforeSetInForTable(CallContext context) throws ParseException {
+    public void testInFilterWithRangeInOtherCursorBeforeSetInForTable(CallContext context) {
         AFilterCursor a = new AFilterCursor(context);
         BFilterCursor b = new BFilterCursor(context);
         _testInFilterWithRangeInOtherCursorBeforeSetIn(context, a, b);
     }
 
     @TestTemplate
-    public void testInFilterWithRangeInOtherCursorBeforeSetInForView(CallContext context) throws ParseException {
+    public void testInFilterWithRangeInOtherCursorBeforeSetInForView(CallContext context) {
         AFilterViewCursor a = new AFilterViewCursor(context);
         BFilterViewCursor b = new BFilterViewCursor(context);
         _testInFilterWithRangeInOtherCursorBeforeSetIn(context, a, b);
     }
 
     @TestTemplate
-    public void testInFilterWithRangeInOtherCursorBeforeSetInForTableToView(CallContext context) throws ParseException {
+    public void testInFilterWithRangeInOtherCursorBeforeSetInForTableToView(CallContext context) {
         AFilterCursor a = new AFilterCursor(context);
         BFilterViewCursor b = new BFilterViewCursor(context);
         _testInFilterWithRangeInOtherCursorBeforeSetIn(context, a, b);
     }
 
     @TestTemplate
-    public void testInFilterWithRangeInOtherCursorAfterSetInForTable(CallContext context) throws ParseException {
+    public void testInFilterWithRangeInOtherCursorAfterSetInForTable(CallContext context) {
         AFilterCursor a = new AFilterCursor(context);
         BFilterCursor b = new BFilterCursor(context);
         _testInFilterWithRangeInOtherCursorAfterSetIn(context, a, b);
     }
 
     @TestTemplate
-    public void testInFilterWithRangeInOtherCursorAfterSetInForView(CallContext context) throws ParseException {
+    public void testInFilterWithRangeInOtherCursorAfterSetInForView(CallContext context) {
         AFilterViewCursor a = new AFilterViewCursor(context);
         BFilterViewCursor b = new BFilterViewCursor(context);
         _testInFilterWithRangeInOtherCursorAfterSetIn(context, a, b);
     }
 
     @TestTemplate
-    public void testInFilterWithAdditionalLookupForTable(CallContext context) throws ParseException {
+    public void testInFilterWithAdditionalLookupForTable(CallContext context) {
         AFilterCursor a = new AFilterCursor(context);
         BFilterCursor b = new BFilterCursor(context);
         GFilterCursor g = new GFilterCursor(context);
@@ -180,7 +180,7 @@ public class TestFilter implements ScriptTest {
     }
 
     @TestTemplate
-    public void testInFilterWithAdditionalLookupForView(CallContext context) throws ParseException {
+    public void testInFilterWithAdditionalLookupForView(CallContext context) {
         AFilterViewCursor a = new AFilterViewCursor(context);
         BFilterViewCursor b = new BFilterViewCursor(context);
         GFilterViewCursor g = new GFilterViewCursor(context);
@@ -188,7 +188,7 @@ public class TestFilter implements ScriptTest {
     }
 
     @TestTemplate
-    public void testInFilterWithAdditionalLookupForTableToView(CallContext context) throws ParseException {
+    public void testInFilterWithAdditionalLookupForTableToView(CallContext context) {
         AFilterCursor a = new AFilterCursor(context);
         BFilterViewCursor b = new BFilterViewCursor(context);
         GFilterViewCursor g = new GFilterViewCursor(context);
@@ -196,7 +196,7 @@ public class TestFilter implements ScriptTest {
     }
 
     @TestTemplate
-    public void testInFilterWhenTargetHasPkAndOtherHasPkWithNotSameOrderAndIndexWithSameOrder(CallContext context) throws ParseException {
+    public void testInFilterWhenTargetHasPkAndOtherHasPkWithNotSameOrderAndIndexWithSameOrder(CallContext context) {
         HFilterCursor h = new HFilterCursor(context);
         IFilterCursor i = new IFilterCursor(context);
 
@@ -323,7 +323,7 @@ public class TestFilter implements ScriptTest {
         b.clear();
     }
 
-    void _testInFilterForIndices(CallContext context, BasicCursor a, BasicCursor b) throws ParseException {
+    void _testInFilterForIndices(CallContext context, BasicCursor a, BasicCursor b) {
         AFilterCursor aTableCursor = new AFilterCursor(context);
         BFilterCursor bTableCursor = new BFilterCursor(context);
 
@@ -371,7 +371,7 @@ public class TestFilter implements ScriptTest {
         assertEquals(0, a.count());
     }
 
-    void _testInFilterWithRangeInMainCursor(CallContext context, BasicCursor a, BasicCursor b) throws ParseException {
+    void _testInFilterWithRangeInMainCursor(CallContext context, BasicCursor a, BasicCursor b) {
         AFilterCursor aTableCursor = new AFilterCursor(context);
         BFilterCursor bTableCursor = new BFilterCursor(context);
 
@@ -435,7 +435,7 @@ public class TestFilter implements ScriptTest {
         }
     }
 
-    void _testInFilterWithRangeInOtherCursorBeforeSetIn(CallContext context, BasicCursor a, BasicCursor b) throws ParseException {
+    void _testInFilterWithRangeInOtherCursorBeforeSetIn(CallContext context, BasicCursor a, BasicCursor b) {
         AFilterCursor aTableCursor = new AFilterCursor(context);
         BFilterCursor bTableCursor = new BFilterCursor(context);
 
@@ -458,7 +458,7 @@ public class TestFilter implements ScriptTest {
         checkSecondRec(a);
     }
 
-    void _testInFilterWithRangeInOtherCursorAfterSetIn(CallContext context, BasicCursor a, BasicCursor b) throws ParseException {
+    void _testInFilterWithRangeInOtherCursorAfterSetIn(CallContext context, BasicCursor a, BasicCursor b) {
         AFilterCursor aTableCursor = new AFilterCursor(context);
         BFilterCursor bTableCursor = new BFilterCursor(context);
 
@@ -484,7 +484,7 @@ public class TestFilter implements ScriptTest {
         checkSecondRec(a);
     }
 
-    void _testInFilterWithAdditionalLookup(CallContext context, BasicCursor a, BasicCursor b, BasicCursor g) throws ParseException {
+    void _testInFilterWithAdditionalLookup(CallContext context, BasicCursor a, BasicCursor b, BasicCursor g) {
         AFilterCursor aTableCursor = new AFilterCursor(context);
         BFilterCursor bTableCursor = new BFilterCursor(context);
         GFilterCursor gTableCursor = new GFilterCursor(context);

--- a/celesta-unit/src/test/java/ru/curs/celestaunit/CelestaUnitAnnotatedExtensionTest.java
+++ b/celesta-unit/src/test/java/ru/curs/celestaunit/CelestaUnitAnnotatedExtensionTest.java
@@ -1,0 +1,56 @@
+package ru.curs.celestaunit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import ru.curs.celesta.CallContext;
+import s1.HeaderCursor;
+import s1.LineCursor;
+import s1.Seq1Sequence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@CelestaTest(referentialIntegrity = false,
+        truncateTables = false,
+        resetSequences = false)
+public class CelestaUnitAnnotatedExtensionTest {
+    @Test
+    void integrityCheckDoesNotWork(CallContext ctx) {
+        try(LineCursor lc = new LineCursor(ctx)) {
+            lc.setHeader_id(100);
+            lc.setId(100);
+            lc.insert();
+        }
+    }
+
+    @Test
+    @DisplayName("When truncateAfterEach is off, tables that are filled in a test...")
+    void tablesNotTruncated1(CallContext ctx) {
+        CelestaUnitExtensionTest.fillTwoTables(ctx);
+    }
+
+    @Test
+    @DisplayName("...can be read in the following test.")
+    void tablesNotTruncated2(CallContext ctx) {
+        try(LineCursor lc = new LineCursor(ctx);
+            HeaderCursor hc = new HeaderCursor(ctx)) {
+
+            assertEquals(1, hc.count());
+            assertEquals(1, lc.count());
+        }
+    }
+
+    @Test
+    @DisplayName("When resetSequences is on, and you get a value from sequence...")
+    public void sequencesReset1(CallContext ctx){
+        Seq1Sequence sequence = new Seq1Sequence(ctx);
+        assertEquals(1, sequence.nextValue());
+    }
+
+
+    @Test
+    @DisplayName("...this value persists in the following test")
+    public void sequencesReset2(CallContext ctx){
+        Seq1Sequence sequence = new Seq1Sequence(ctx);
+        assertEquals(2, sequence.nextValue());
+    }
+}


### PR DESCRIPTION
## Overview

`InFilter` throws checked ParseException, which is inconvenent

---

### Checklist

- [ ] Change is covered by automated tests.
- [ ] JavaDoc / User Guide is updated.
- [x] CI builds pass.
- [x] PR is tagged.
