### PR TITLE
use `this` in generated cursors to avoid field shadowing

### DIFF
--- a/celesta-maven-plugin/src/main/java/ru/curs/celesta/plugin/maven/CursorGenerator.java
+++ b/celesta-maven-plugin/src/main/java/ru/curs/celesta/plugin/maven/CursorGenerator.java
@@ -663,7 +663,7 @@ public final class CursorGenerator {
                 .beginControlFlow("switch (name)");
 
         for (String columnName : columns.keySet()) {
-            builder.addStatement("case $S: return $N", columnName, camelize(columnName));
+            builder.addStatement("case $S: return this.$N", columnName, camelize(columnName));
         }
         builder.addStatement("default: return null").endControlFlow();
 
@@ -682,7 +682,7 @@ public final class CursorGenerator {
                 .beginControlFlow("switch (name)");
         for (Map.Entry<String, ? extends ColumnMeta<?>> column : columns.entrySet()) {
             builder.beginControlFlow("case $S:", column.getKey())
-                    .addStatement("$N = ($T) $N", camelize(column.getKey()),
+                    .addStatement("this.$N = ($T) $N", camelize(column.getKey()),
                             column.getValue().getJavaClass(),
                             valueParam)
                     .addStatement("break")

--- a/celesta-maven-plugin/src/test/resources/gen-cursors/expectedGenerationResults/data/table/TestRoTableCursor.java
+++ b/celesta-maven-plugin/src/test/resources/gen-cursors/expectedGenerationResults/data/table/TestRoTableCursor.java
@@ -61,7 +61,7 @@ public class TestRoTableCursor extends ReadOnlyTableCursor implements Iterable<T
     protected Object _getFieldValue(String name) {
         switch (name) {
             case "id":
-                return id;
+                return this.id;
             default:
                 return null;
         }
@@ -71,7 +71,7 @@ public class TestRoTableCursor extends ReadOnlyTableCursor implements Iterable<T
     protected void _setFieldValue(String name, Object value) {
         switch (name) {
             case "id": {
-                id = (Integer) value;
+                this.id = (Integer) value;
                 break;
             }
             default:;

--- a/celesta-maven-plugin/src/test/resources/gen-cursors/expectedGenerationResults/data/table/TestSnakeTableCursor.java
+++ b/celesta-maven-plugin/src/test/resources/gen-cursors/expectedGenerationResults/data/table/TestSnakeTableCursor.java
@@ -125,17 +125,17 @@ public class TestSnakeTableCursor extends Cursor implements Iterable<TestSnakeTa
     protected Object _getFieldValue(String name) {
         switch (name) {
             case "snake_field":
-                return snakeField;
+                return this.snakeField;
             case "snake_blob":
-                return snakeBlob;
+                return this.snakeBlob;
             case "date_one":
-                return dateOne;
+                return this.dateOne;
             case "date_two":
-                return dateTwo;
+                return this.dateTwo;
             case "text_field":
-                return textField;
+                return this.textField;
             case "status_field":
-                return statusField;
+                return this.statusField;
             default:
                 return null;
         }
@@ -145,27 +145,27 @@ public class TestSnakeTableCursor extends Cursor implements Iterable<TestSnakeTa
     protected void _setFieldValue(String name, Object value) {
         switch (name) {
             case "snake_field": {
-                snakeField = (Integer) value;
+                this.snakeField = (Integer) value;
                 break;
             }
             case "snake_blob": {
-                snakeBlob = (BLOB) value;
+                this.snakeBlob = (BLOB) value;
                 break;
             }
             case "date_one": {
-                dateOne = (Date) value;
+                this.dateOne = (Date) value;
                 break;
             }
             case "date_two": {
-                dateTwo = (ZonedDateTime) value;
+                this.dateTwo = (ZonedDateTime) value;
                 break;
             }
             case "text_field": {
-                textField = (String) value;
+                this.textField = (String) value;
                 break;
             }
             case "status_field": {
-                statusField = (Integer) value;
+                this.statusField = (Integer) value;
                 break;
             }
             default:;

--- a/celesta-maven-plugin/src/test/resources/gen-cursors/expectedGenerationResults/data/table/TestTableCursor.java
+++ b/celesta-maven-plugin/src/test/resources/gen-cursors/expectedGenerationResults/data/table/TestTableCursor.java
@@ -161,23 +161,23 @@ public class TestTableCursor extends Cursor implements Iterable<TestTableCursor>
     protected Object _getFieldValue(String name) {
         switch (name) {
             case "id":
-                return id;
+                return this.id;
             case "str":
-                return str;
+                return this.str;
             case "deleted":
-                return deleted;
+                return this.deleted;
             case "weight":
-                return weight;
+                return this.weight;
             case "content":
-                return content;
+                return this.content;
             case "created":
-                return created;
+                return this.created;
             case "rawData":
-                return rawData;
+                return this.rawData;
             case "cost":
-                return cost;
+                return this.cost;
             case "toDelete":
-                return toDelete;
+                return this.toDelete;
             default:
                 return null;
         }
@@ -187,39 +187,39 @@ public class TestTableCursor extends Cursor implements Iterable<TestTableCursor>
     protected void _setFieldValue(String name, Object value) {
         switch (name) {
             case "id": {
-                id = (Integer) value;
+                this.id = (Integer) value;
                 break;
             }
             case "str": {
-                str = (String) value;
+                this.str = (String) value;
                 break;
             }
             case "deleted": {
-                deleted = (Boolean) value;
+                this.deleted = (Boolean) value;
                 break;
             }
             case "weight": {
-                weight = (Double) value;
+                this.weight = (Double) value;
                 break;
             }
             case "content": {
-                content = (String) value;
+                this.content = (String) value;
                 break;
             }
             case "created": {
-                created = (Date) value;
+                this.created = (Date) value;
                 break;
             }
             case "rawData": {
-                rawData = (BLOB) value;
+                this.rawData = (BLOB) value;
                 break;
             }
             case "cost": {
-                cost = (BigDecimal) value;
+                this.cost = (BigDecimal) value;
                 break;
             }
             case "toDelete": {
-                toDelete = (ZonedDateTime) value;
+                this.toDelete = (ZonedDateTime) value;
                 break;
             }
             default:;

--- a/celesta-maven-plugin/src/test/resources/gen-cursors/expectedGenerationResults/data/view/TestTableMvCursor.java
+++ b/celesta-maven-plugin/src/test/resources/gen-cursors/expectedGenerationResults/data/view/TestTableMvCursor.java
@@ -84,11 +84,11 @@ public class TestTableMvCursor extends MaterializedViewCursor implements Iterabl
     protected Object _getFieldValue(String name) {
         switch (name) {
             case "surrogate_count":
-                return surrogateCount;
+                return this.surrogateCount;
             case "c":
-                return c;
+                return this.c;
             case "cost":
-                return cost;
+                return this.cost;
             default:
                 return null;
         }
@@ -98,15 +98,15 @@ public class TestTableMvCursor extends MaterializedViewCursor implements Iterabl
     protected void _setFieldValue(String name, Object value) {
         switch (name) {
             case "surrogate_count": {
-                surrogateCount = (Integer) value;
+                this.surrogateCount = (Integer) value;
                 break;
             }
             case "c": {
-                c = (Integer) value;
+                this.c = (Integer) value;
                 break;
             }
             case "cost": {
-                cost = (BigDecimal) value;
+                this.cost = (BigDecimal) value;
                 break;
             }
             default:;

--- a/celesta-maven-plugin/src/test/resources/gen-cursors/expectedGenerationResults/data/view/TestTablePvCursor.java
+++ b/celesta-maven-plugin/src/test/resources/gen-cursors/expectedGenerationResults/data/view/TestTablePvCursor.java
@@ -79,7 +79,7 @@ public class TestTablePvCursor extends ParameterizedViewCursor implements Iterab
     protected Object _getFieldValue(String name) {
         switch (name) {
             case "s":
-                return s;
+                return this.s;
             default:
                 return null;
         }
@@ -89,7 +89,7 @@ public class TestTablePvCursor extends ParameterizedViewCursor implements Iterab
     protected void _setFieldValue(String name, Object value) {
         switch (name) {
             case "s": {
-                s = (Integer) value;
+                this.s = (Integer) value;
                 break;
             }
             default:;

--- a/celesta-maven-plugin/src/test/resources/gen-cursors/expectedGenerationResults/data/view/TestTableVCursor.java
+++ b/celesta-maven-plugin/src/test/resources/gen-cursors/expectedGenerationResults/data/view/TestTableVCursor.java
@@ -76,9 +76,9 @@ public class TestTableVCursor extends ViewCursor implements Iterable<TestTableVC
     protected Object _getFieldValue(String name) {
         switch (name) {
             case "id":
-                return id;
+                return this.id;
             case "toDelete":
-                return toDelete;
+                return this.toDelete;
             default:
                 return null;
         }
@@ -88,11 +88,11 @@ public class TestTableVCursor extends ViewCursor implements Iterable<TestTableVC
     protected void _setFieldValue(String name, Object value) {
         switch (name) {
             case "id": {
-                id = (Integer) value;
+                this.id = (Integer) value;
                 break;
             }
             case "toDelete": {
-                toDelete = (ZonedDateTime) value;
+                this.toDelete = (ZonedDateTime) value;
                 break;
             }
             default:;


### PR DESCRIPTION
## Overview

use `this` in generated cursors to avoid field shadowing

---

### Checklist

- [ ] Change is covered by automated tests.
- [ ] JavaDoc / User Guide is updated.
- [ ] CI builds pass.
- [ ] PR is tagged.
