### PR TITLE
Bugfix: truncate materialized views after each test

### DIFF
--- a/celesta-unit/src/main/java/ru/curs/celestaunit/CelestaUnitExtension.java
+++ b/celesta-unit/src/main/java/ru/curs/celestaunit/CelestaUnitExtension.java
@@ -13,6 +13,7 @@ import ru.curs.celesta.Celesta;
 import ru.curs.celesta.CelestaException;
 import ru.curs.celesta.SystemCallContext;
 import ru.curs.celesta.score.Grain;
+import ru.curs.celesta.score.MaterializedView;
 import ru.curs.celesta.score.Score;
 import ru.curs.celesta.score.BasicTable;
 import ru.curs.celesta.score.SequenceElement;
@@ -152,6 +153,11 @@ public final class CelestaUnitExtension implements BeforeAllCallback,
                         stmt.execute(String.format("truncate table %s.%s",
                                 grain.getQuotedName(),
                                 table.getQuotedName()));
+                    }
+                    for (MaterializedView view : grain.getMaterializedViews().values()) {
+                        stmt.execute(String.format("truncate table %s.%s",
+                                grain.getQuotedName(),
+                                view.getQuotedName()));
                     }
                 }
             }

--- a/celesta-unit/src/test/java/ru/curs/celestaunit/CelestaUnitExtensionTest.java
+++ b/celesta-unit/src/test/java/ru/curs/celestaunit/CelestaUnitExtensionTest.java
@@ -118,6 +118,8 @@ public class CelestaUnitExtensionTest {
     @Test
     @DisplayName("...their content is cleared")
     void mvReset2(CallContext ctx) {
+        LinecountCursor linecountCursor = new LinecountCursor(ctx);
+        assertEquals(0, linecountCursor.count());
         HeaderCursor headerCursor = new HeaderCursor(ctx);
         headerCursor.setId(42);
         headerCursor.insert();
@@ -125,7 +127,6 @@ public class CelestaUnitExtensionTest {
         lineCursor.setId(7);
         lineCursor.setHeaderId(headerCursor.getId());
         lineCursor.insert();
-        LinecountCursor linecountCursor = new LinecountCursor(ctx);
         linecountCursor.get(42);
         assertEquals(7, linecountCursor.getLineCount());
     }


### PR DESCRIPTION
## Overview

Celesta unit didn't truncate materialized views after each test.

---

### Checklist

- [x] Change is covered by automated tests.
- [ ] JavaDoc / User Guide is updated.
- [x] CI builds pass.
- [x] PR is tagged.
