### PR TITLE
make CursorGenerator api public

### DIFF
--- a/celesta-maven-plugin/src/main/java/ru/curs/celesta/plugin/maven/CursorGenerator.java
+++ b/celesta-maven-plugin/src/main/java/ru/curs/celesta/plugin/maven/CursorGenerator.java
@@ -117,12 +117,22 @@ public final class CursorGenerator {
     private final File srcDir;
     private final boolean snakeToCamel;
 
-    CursorGenerator(File srcDir, boolean snakeToCamel) {
+    /**
+     * Creates code generator for data accessor classes.
+     * @param srcDir Path to directory where generated files should be put
+     * @param snakeToCamel True if snake_case identifiers should be converted to camelCase
+     */
+    public CursorGenerator(File srcDir, boolean snakeToCamel) {
         this.srcDir = srcDir;
         this.snakeToCamel = snakeToCamel;
     }
 
-    void generateCursor(GrainElement ge, String scorePath) {
+    /**
+     * Generate code for schema (grain) element.
+     * @param ge Schema (grain) element
+     * @param scorePath path to CelestaSQL file
+     */
+    public void generateCursor(GrainElement ge, String scorePath) {
         final String sourcePackage = calcSourcePackage(ge, scorePath);
 
         if (sourcePackage.isEmpty()) {


### PR DESCRIPTION
## Overview

Make two methods of `CursorGenerator` public in order to make it possible to build Celesta projects with Gradle

---

### Checklist

- NA Change is covered by automated tests.
- [X] JavaDoc / User Guide is updated.
- [x] CI builds pass.
- [x] PR is tagged.
