### PR TITLE
Fix version of poms

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,9 +47,10 @@ jobs:
           chmod +x spellcheck 
           ./spellcheck en
           ./spellcheck ru
-      
+      - name: Build prerequisites
+        run: mvn install -pl celesta-maven-plugin -DskipTests -Dspotbugs.skip=true -am 
       - name: Build Javadoc
-        run: mvn javadoc:aggregate -pl :celesta-parent,:celesta-sql,:celesta-core,:celesta-system-services,:celesta-unit
+        run: mvn javadoc:aggregate -pl :celesta-parent,:celesta-sql,:celesta-core,:celesta-system-services,:celesta-unit,:celesta-maven-plugin
       - name: Build documentation
         run: JAVA_HOME=$JDK_11; mvn generate-resources -pl :celesta-documentation       
       - name: Move Javadoc

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Build prerequisites
         run: mvn install -pl celesta-maven-plugin -DskipTests -Dspotbugs.skip=true -am 
       - name: Build Javadoc
-        run: mvn javadoc:aggregate -pl :celesta-parent,:celesta-sql,:celesta-core,:celesta-system-services,:celesta-unit,:celesta-maven-plugin
+        run: mvn javadoc:aggregate -pl :celesta-parent,:celesta-sql,:celesta-core,:celesta-system-services,:celesta-unit
       - name: Build documentation
         run: JAVA_HOME=$JDK_11; mvn generate-resources -pl :celesta-documentation       
       - name: Move Javadoc

--- a/celesta-core/pom.xml
+++ b/celesta-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>celesta-parent</artifactId>
         <groupId>ru.curs</groupId>
-        <version>7.4.38-SNAPSHOT</version>
+        <version>7.4.39</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-sql</artifactId>
-            <version>7.4.38-SNAPSHOT</version>
+            <version>7.4.39</version>
         </dependency>
 
         <!-- TEST DEPENDENCIES -->

--- a/celesta-core/pom.xml
+++ b/celesta-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>celesta-parent</artifactId>
         <groupId>ru.curs</groupId>
-        <version>7.4.39</version>
+        <version>7.4.39-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-sql</artifactId>
-            <version>7.4.39</version>
+            <version>7.4.39-SNAPSHOT</version>
         </dependency>
 
         <!-- TEST DEPENDENCIES -->

--- a/celesta-documentation/pom.xml
+++ b/celesta-documentation/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>celesta-parent</artifactId>
         <groupId>ru.curs</groupId>
-        <version>7.4.39</version>
+        <version>7.4.39-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/celesta-documentation/pom.xml
+++ b/celesta-documentation/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>celesta-parent</artifactId>
         <groupId>ru.curs</groupId>
-        <version>7.4.38-SNAPSHOT</version>
+        <version>7.4.39</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/celesta-maven-plugin/pom.xml
+++ b/celesta-maven-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>celesta-parent</artifactId>
         <groupId>ru.curs</groupId>
-        <version>7.4.38-SNAPSHOT</version>
+        <version>7.4.39</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-core</artifactId>
-            <version>7.4.38-SNAPSHOT</version>
+            <version>7.4.39</version>
         </dependency>
         <dependency>
             <groupId>com.squareup</groupId>

--- a/celesta-maven-plugin/pom.xml
+++ b/celesta-maven-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>celesta-parent</artifactId>
         <groupId>ru.curs</groupId>
-        <version>7.4.39</version>
+        <version>7.4.39-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-core</artifactId>
-            <version>7.4.39</version>
+            <version>7.4.39-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.squareup</groupId>

--- a/celesta-sql/pom.xml
+++ b/celesta-sql/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>celesta-parent</artifactId>
         <groupId>ru.curs</groupId>
-        <version>7.4.39</version>
+        <version>7.4.39-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/celesta-sql/pom.xml
+++ b/celesta-sql/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>celesta-parent</artifactId>
         <groupId>ru.curs</groupId>
-        <version>7.4.38-SNAPSHOT</version>
+        <version>7.4.39</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/celesta-system-services/pom.xml
+++ b/celesta-system-services/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>celesta-parent</artifactId>
         <groupId>ru.curs</groupId>
-        <version>7.4.39</version>
+        <version>7.4.39-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-core</artifactId>
-            <version>7.4.39</version>
+            <version>7.4.39-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/celesta-system-services/pom.xml
+++ b/celesta-system-services/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>celesta-parent</artifactId>
         <groupId>ru.curs</groupId>
-        <version>7.4.38-SNAPSHOT</version>
+        <version>7.4.39</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-core</artifactId>
-            <version>7.4.38-SNAPSHOT</version>
+            <version>7.4.39</version>
         </dependency>
     </dependencies>
 

--- a/celesta-test/pom.xml
+++ b/celesta-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>celesta-parent</artifactId>
         <groupId>ru.curs</groupId>
-        <version>7.4.39</version>
+        <version>7.4.39-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -44,14 +44,14 @@
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-system-services</artifactId>
-            <version>7.4.39</version>
+            <version>7.4.39-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-core</artifactId>
-            <version>7.4.39</version>
+            <version>7.4.39-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/celesta-test/pom.xml
+++ b/celesta-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>celesta-parent</artifactId>
         <groupId>ru.curs</groupId>
-        <version>7.4.38-SNAPSHOT</version>
+        <version>7.4.39</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -44,14 +44,14 @@
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-system-services</artifactId>
-            <version>7.4.38-SNAPSHOT</version>
+            <version>7.4.39</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-core</artifactId>
-            <version>7.4.38-SNAPSHOT</version>
+            <version>7.4.39</version>
         </dependency>
 
         <dependency>

--- a/celesta-unit/pom.xml
+++ b/celesta-unit/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>celesta-parent</artifactId>
         <groupId>ru.curs</groupId>
-        <version>7.4.38-SNAPSHOT</version>
+        <version>7.4.39</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -18,13 +18,13 @@
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-core</artifactId>
-            <version>7.4.38-SNAPSHOT</version>
+            <version>7.4.39</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-system-services</artifactId>
-            <version>7.4.38-SNAPSHOT</version>
+            <version>7.4.39</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/celesta-unit/pom.xml
+++ b/celesta-unit/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>celesta-parent</artifactId>
         <groupId>ru.curs</groupId>
-        <version>7.4.39</version>
+        <version>7.4.39-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -18,13 +18,13 @@
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-core</artifactId>
-            <version>7.4.39</version>
+            <version>7.4.39-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-system-services</artifactId>
-            <version>7.4.39</version>
+            <version>7.4.39-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>celesta-parent</artifactId>
         <groupId>ru.curs</groupId>
-        <version>7.4.38-SNAPSHOT</version>
+        <version>7.4.39</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
@@ -12,32 +12,32 @@
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-test</artifactId>
-            <version>7.4.38-SNAPSHOT</version>
+            <version>7.4.39</version>
         </dependency>
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-unit</artifactId>
-            <version>7.4.38-SNAPSHOT</version>
+            <version>7.4.39</version>
         </dependency>
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-maven-plugin</artifactId>
-            <version>7.4.38-SNAPSHOT</version>
+            <version>7.4.39</version>
         </dependency>
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-sql</artifactId>
-            <version>7.4.38-SNAPSHOT</version>
+            <version>7.4.39</version>
         </dependency>
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-core</artifactId>
-            <version>7.4.38-SNAPSHOT</version>
+            <version>7.4.39</version>
         </dependency>
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-system-services</artifactId>
-            <version>7.4.38-SNAPSHOT</version>
+            <version>7.4.39</version>
         </dependency>
     </dependencies>
 

--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>celesta-parent</artifactId>
         <groupId>ru.curs</groupId>
-        <version>7.4.39</version>
+        <version>7.4.39-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
@@ -12,32 +12,32 @@
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-test</artifactId>
-            <version>7.4.39</version>
+            <version>7.4.39-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-unit</artifactId>
-            <version>7.4.39</version>
+            <version>7.4.39-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-maven-plugin</artifactId>
-            <version>7.4.39</version>
+            <version>7.4.39-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-sql</artifactId>
-            <version>7.4.39</version>
+            <version>7.4.39-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-core</artifactId>
-            <version>7.4.39</version>
+            <version>7.4.39-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ru.curs</groupId>
             <artifactId>celesta-system-services</artifactId>
-            <version>7.4.39</version>
+            <version>7.4.39-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>ru.curs</groupId>
     <artifactId>celesta-parent</artifactId>
-    <version>7.4.39</version>
+    <version>7.4.39-SNAPSHOT</version>
     <name>celesta-parent</name>
     <description>celesta - LGPL platform for business logic development</description>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>ru.curs</groupId>
     <artifactId>celesta-parent</artifactId>
-    <version>7.4.38-SNAPSHOT</version>
+    <version>7.4.39</version>
     <name>celesta-parent</name>
     <description>celesta - LGPL platform for business logic development</description>
     <packaging>pom</packaging>

--- a/update4release.sh
+++ b/update4release.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+find . -name "pom.xml" | while read file
+do
+    sed -i -E 's|([ ]*<version>7\.4\.)([0-9]+)-SNAPSHOT</version>|echo "\1$((\2 + 1))</version>"|ge' "$file"
+done

--- a/update4snapshot.sh
+++ b/update4snapshot.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+find . -name "pom.xml" | while read file
+do
+    sed -i -E 's|(<version>7\.4\.[0-9]+)</version>|\1-SNAPSHOT</version>|g' "$file"
+done


### PR DESCRIPTION
## Overview

ReleaseJenkinsfile failed because of change of public keys on GitHub

---

### Checklist

- [ ] Change is covered by automated tests.
- [ ] JavaDoc / User Guide is updated.
- [ ] CI builds pass.
- [ ] PR is tagged.
