### PR TITLE
dependabot should not publish test report

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Publish test report
         uses: dorny/test-reporter@v1
-        if: success() || failure()    
+        if: (success() || failure()) && github.actor != 'dependabot[bot]'
         with:
           name: Test report          
           path: '**/surefire-reports/**/*.xml'    


### PR DESCRIPTION
## Overview

Since dependabot has only read-only token, it cannot publish the test report

---

### Checklist

- [ ] Change is covered by automated tests.
- [ ] JavaDoc / User Guide is updated.
- [ ] CI builds pass.
- [ ] PR is tagged.
