### PR TITLE
Modern way to bild syntax diagrams with JSyntrax

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,12 +35,9 @@ jobs:
         run: sudo apt-get install -y aspell-en aspell-ru graphviz
       - name: Install jsyntrax
         run: |
-          wget https://github.com/atp-mipt/jsyntrax/releases/download/1.1/jsyntrax-1.1-syntrax.zip -nv -O jsyntrax.zip
+          wget https://github.com/atp-mipt/jsyntrax/releases/download/1.37/jsyntrax-1.37-syntrax.zip -nv -O jsyntrax.zip
           unzip -q jsyntrax.zip
           rm jsyntrax.zip
-          sudo chmod +x $(pwd)/jsyntrax-1.1/bin/syntrax
-          sudo ln -s $(pwd)/jsyntrax-1.1/bin/syntrax /usr/local/bin/syntrax
-          JAVA_HOME=$JDK_11; syntrax --version
       
       - name: Spellcheck
         run: |
@@ -52,7 +49,10 @@ jobs:
       - name: Build Javadoc
         run: mvn javadoc:aggregate -pl :celesta-parent,:celesta-sql,:celesta-core,:celesta-system-services,:celesta-unit
       - name: Build documentation
-        run: JAVA_HOME=$JDK_11; mvn generate-resources -pl :celesta-documentation       
+        run: mvn generate-resources -pl :celesta-documentation
+        env:
+          JAVA_HOME: $JDK_11
+          DIAGRAM_JSYNTRAX_HOME: ${{ github.workspace }}/jsyntrax-1.37
       - name: Move Javadoc
         run: mv target/site/apidocs celesta-documentation/target/generated-docs/apidocs
       - name: Deploy to GitHub Pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-
-      - name: Install apell and graphviz
+      - name: Install aspell and graphviz
         run: sudo apt-get install -y aspell-en aspell-ru graphviz
       - name: Install jsyntrax
         run: |
@@ -51,7 +51,7 @@ jobs:
       - name: Build documentation
         run: mvn generate-resources -pl :celesta-documentation
         env:
-          JAVA_HOME: $JDK_11
+          JAVA_HOME: ${{ env.JDK_11 }}
           DIAGRAM_JSYNTRAX_HOME: ${{ github.workspace }}/jsyntrax-1.37
       - name: Move Javadoc
         run: mv target/site/apidocs celesta-documentation/target/generated-docs/apidocs

--- a/celesta-documentation/pom.xml
+++ b/celesta-documentation/pom.xml
@@ -44,7 +44,7 @@
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj-diagram</artifactId>
-                        <version>2.2.7</version>
+                        <version>2.2.8</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/celesta-documentation/src/main/asciidoc/jsyntrax.ini
+++ b/celesta-documentation/src/main/asciidoc/jsyntrax.ini
@@ -10,7 +10,7 @@ arrows = True
 title_pos = 'tl'
 bullet_fill = (255, 255, 255)
 text_color = (0, 0, 0)
-shadow = True
+shadow = False
 shadow_fill = (0, 0, 0, 127)
 title_font = ('Sans', 22, 'bold')
 


### PR DESCRIPTION
## Overview

Since  asciidoctor-diatram 2.2.8, it's possible to build jsyntrax diagrams in more effective way

---

### Checklist

- [x] Change is covered by automated tests.
- [x] JavaDoc / User Guide is updated.
- [x] CI builds pass.
- [x] PR is tagged.
