### PR TITLE
Fix insertion of sequence values which are not PKs

### DIFF
--- a/celesta-sql/src/main/java/ru/curs/celesta/dbutils/adaptors/H2Adaptor.java
+++ b/celesta-sql/src/main/java/ru/curs/celesta/dbutils/adaptors/H2Adaptor.java
@@ -136,11 +136,23 @@ public final class H2Adaptor extends OpenSourceDbAdaptor {
             program.add(ParameterSetter.create(i, this));
         }
 
+        String returning = null;
+        for (Column<?> c : t.getColumns().values()) {
+            if (c instanceof IntegerColumn) {
+                IntegerColumn ic = (IntegerColumn) c;
+                if (ic.getSequence() != null) {
+                    returning = c.getQuotedName();
+                    break;
+                }
+            }
+        }
 
         String sql = String.format(
-                "insert into " + tableString(t.getGrain().getName(), t.getName()) + " (%s) "
-                        + "values (%s)", fields, params
+                "insert into %s (%s) values (%s)", tableString(t.getGrain().getName(), t.getName()), fields, params
         );
+        if (returning != null) {
+            sql = String.format("select %s from final table (%s)", returning, sql);
+        }
 
         return prepareStatement(conn, sql);
     }

--- a/celesta-sql/src/main/java/ru/curs/celesta/dbutils/adaptors/MSSQLAdaptor.java
+++ b/celesta-sql/src/main/java/ru/curs/celesta/dbutils/adaptors/MSSQLAdaptor.java
@@ -177,17 +177,13 @@ public final class MSSQLAdaptor extends DBAdaptor {
             program.add(ParameterSetter.create(i, this));
         }
 
+
         final String sql;
         String output = "";
-        for (Column<?> c : t.getColumns().values()) {
-            if (c instanceof IntegerColumn) {
-                IntegerColumn ic = (IntegerColumn) c;
-
-                if (ic.getSequence() != null) {
-                    output = "output INSERTED." + c.getQuotedName();
-                    break;
-                }
-            }
+        if (!t.hasMaterializedViews()) {
+            output = t.getAutoincrementedColumn().map(ic ->
+                    "output INSERTED." + ic.getQuotedName()
+            ).orElse("");
         }
 
         if (fields.length() == 0 && params.length() == 0) {
@@ -227,29 +223,18 @@ public final class MSSQLAdaptor extends DBAdaptor {
 
     @Override
     public int getCurrentIdent(Connection conn, BasicTable t) {
-        final String sql;
-
-        IntegerColumn idColumn = t.getPrimaryKey().values().stream()
-                .filter(c -> c instanceof IntegerColumn)
-                .map(c -> (IntegerColumn) c)
-                .filter(ic -> ic.getSequence() != null)
-                .findFirst().get();
-
-
-        sql = String.format(
+        IntegerColumn idColumn = t.getAutoincrementedColumn()
+                .orElseThrow(() -> new CelestaException("Integer auto-incremented column not found"));
+        String sql = String.format(
                 "SELECT CURRENT_VALUE FROM SYS.sequences WHERE name = '%s'",
                 idColumn.getSequence().getName());
-
-        try (Statement stmt = conn.createStatement();
-             ResultSet rs = stmt.executeQuery(sql)) {
+        return SqlUtils.executeQuery(conn, sql, rs -> {
             if (!rs.next()) {
                 throw new CelestaException("Id sequence for %s.%s is not initialized.", t.getGrain().getName(),
                         t.getName());
             }
             return (int) rs.getLong(1);
-        } catch (SQLException e) {
-            throw new CelestaException(e.getMessage(), e);
-        }
+        });
     }
 
     @Override

--- a/celesta-sql/src/main/java/ru/curs/celesta/dbutils/adaptors/MSSQLAdaptor.java
+++ b/celesta-sql/src/main/java/ru/curs/celesta/dbutils/adaptors/MSSQLAdaptor.java
@@ -178,13 +178,28 @@ public final class MSSQLAdaptor extends DBAdaptor {
         }
 
         final String sql;
+        String output = "";
+        for (Column<?> c : t.getColumns().values()) {
+            if (c instanceof IntegerColumn) {
+                IntegerColumn ic = (IntegerColumn) c;
+
+                if (ic.getSequence() != null) {
+                    output = "output INSERTED." + c.getQuotedName();
+                    break;
+                }
+            }
+        }
 
         if (fields.length() == 0 && params.length() == 0) {
-            sql = "insert into " + tableString(t.getGrain().getName(), t.getName()) + " default values;";
+            sql = String.format("insert into %s %s default values;",
+                    tableString(t.getGrain().getName(), t.getName()), output);
         } else {
             sql = String.format(
-                    "insert " + tableString(t.getGrain().getName(), t.getName())
-                            + " (%s) values (%s);", fields, params
+                    "insert %s (%s) %s values (%s);",
+                    tableString(t.getGrain().getName(), t.getName()),
+                    fields,
+                    output,
+                    params
             );
         }
 

--- a/celesta-sql/src/main/java/ru/curs/celesta/dbutils/adaptors/OraAdaptor.java
+++ b/celesta-sql/src/main/java/ru/curs/celesta/dbutils/adaptors/OraAdaptor.java
@@ -321,11 +321,8 @@ public final class OraAdaptor extends DBAdaptor {
     public int getCurrentIdent(Connection conn, BasicTable t) {
         final String sequenceName;
 
-        IntegerColumn idColumn = t.getColumns().values().stream()
-                .filter(c -> c instanceof IntegerColumn)
-                .map(c -> (IntegerColumn) c)
-                .filter(ic -> ic.getSequence() != null)
-                .findFirst().orElseThrow(() -> new CelestaException("Integer auto-incremented column not found"));
+        IntegerColumn idColumn = t.getAutoincrementedColumn()
+                .orElseThrow(() -> new CelestaException("Integer auto-incremented column not found"));
 
         sequenceName = tableString(t.getGrain().getName(), idColumn.getSequence().getName());
 

--- a/celesta-sql/src/main/java/ru/curs/celesta/dbutils/adaptors/OraAdaptor.java
+++ b/celesta-sql/src/main/java/ru/curs/celesta/dbutils/adaptors/OraAdaptor.java
@@ -42,6 +42,7 @@ import ru.curs.celesta.dbutils.adaptors.ddl.DdlConsumer;
 import ru.curs.celesta.dbutils.adaptors.ddl.DdlGenerator;
 import ru.curs.celesta.dbutils.adaptors.ddl.OraDdlGenerator;
 import ru.curs.celesta.dbutils.adaptors.function.OraFunctions;
+import ru.curs.celesta.dbutils.jdbc.SqlUtils;
 import ru.curs.celesta.dbutils.meta.DbColumnInfo;
 import ru.curs.celesta.dbutils.meta.DbFkInfo;
 import ru.curs.celesta.dbutils.meta.DbIndexInfo;
@@ -320,22 +321,19 @@ public final class OraAdaptor extends DBAdaptor {
     public int getCurrentIdent(Connection conn, BasicTable t) {
         final String sequenceName;
 
-        IntegerColumn idColumn = t.getPrimaryKey().values().stream()
+        IntegerColumn idColumn = t.getColumns().values().stream()
                 .filter(c -> c instanceof IntegerColumn)
                 .map(c -> (IntegerColumn) c)
                 .filter(ic -> ic.getSequence() != null)
-                .findFirst().get();
+                .findFirst().orElseThrow(() -> new CelestaException("Integer auto-incremented column not found"));
 
         sequenceName = tableString(t.getGrain().getName(), idColumn.getSequence().getName());
 
         String sql = String.format("SELECT %s.CURRVAL FROM DUAL", sequenceName);
-        try (Statement stmt = conn.createStatement();
-             ResultSet rs = stmt.executeQuery(sql)) {
+        return SqlUtils.executeQuery(conn, sql, rs -> {
             rs.next();
             return rs.getInt(1);
-        } catch (SQLException e) {
-            throw new CelestaException(e.getMessage(), e);
-        }
+        });
     }
 
     @Override

--- a/celesta-sql/src/main/java/ru/curs/celesta/score/Table.java
+++ b/celesta-sql/src/main/java/ru/curs/celesta/score/Table.java
@@ -18,18 +18,6 @@ public final class Table extends BasicTable implements VersionedElement {
         return true;
     }
 
-    /**
-     * Whether the table is read only (WITH READ ONLY).
-     *
-     * @deprecated left for backwards compatibility.
-     *
-     * @return  always {@code false}
-     */
-    @Deprecated
-    public boolean isReadOnly() {
-        return false;
-    }
-
     @Override
     public boolean isVersioned() {
         return versioned;
@@ -38,7 +26,7 @@ public final class Table extends BasicTable implements VersionedElement {
     /**
      * Sets to the table option "versioned".
      *
-     * @param versioned  "versioned" option value
+     * @param versioned "versioned" option value
      */
     public void setVersioned(boolean versioned) {
         this.versioned = versioned;

--- a/celesta-test/score/simpleCases/_simpleCases.sql
+++ b/celesta-test/score/simpleCases/_simpleCases.sql
@@ -42,6 +42,16 @@ create table usesequence(
   val int not null default nextval(custom)
 );
 
+create table sequenceAndMView(
+  id int not null primary key,
+  val int default nextval(custom),
+  category varchar(3) not null
+);
+
+create materialized view categoryCount as
+       select category, count(*) as cnt from sequenceAndMView group by category;
+
+
 CREATE TABLE forTriggers(
   id INT NOT NULL PRIMARY KEY,
   val INT

--- a/celesta-test/score/simpleCases/_simpleCases.sql
+++ b/celesta-test/score/simpleCases/_simpleCases.sql
@@ -37,6 +37,11 @@ create table duplicate(
 
 create sequence custom;
 
+create table usesequence(
+  id int not null primary key,
+  val int not null default nextval(custom)
+);
+
 CREATE TABLE forTriggers(
   id INT NOT NULL PRIMARY KEY,
   val INT

--- a/celesta-test/src/test/java/ru/curs/celesta/script/CallContextProvider.java
+++ b/celesta-test/src/test/java/ru/curs/celesta/script/CallContextProvider.java
@@ -83,6 +83,7 @@ public class CallContextProvider implements TestTemplateInvocationContextProvide
         containers.putIfAbsent(Backend.PostgreSQL, ContainerUtils.POSTGRE_SQL);
         celestas.computeIfAbsent(Backend.PostgreSQL, b -> celestaFromContainer(containers.get(Backend.PostgreSQL)));
 
+
         containers.putIfAbsent(Backend.Oracle, ContainerUtils.ORACLE);
         celestas.computeIfAbsent(Backend.Oracle, b -> celestaFromContainer(containers.get(Backend.Oracle)));
 

--- a/celesta-test/src/test/java/ru/curs/celesta/script/TestSimpleCases.java
+++ b/celesta-test/src/test/java/ru/curs/celesta/script/TestSimpleCases.java
@@ -11,34 +11,20 @@ import simpleCases.DuplicateCursor;
 import simpleCases.ForTriggersCursor;
 import simpleCases.GetDateForViewCursor;
 import simpleCases.SimpleTableCursor;
+import simpleCases.UsesequenceCursor;
 import simpleCases.ViewWithGetDateCursor;
 import simpleCases.ZeroInsertCursor;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.Date;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TestSimpleCases implements ScriptTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TestSimpleCases.class);
-
-    static class MutableBoolean {
-        private boolean value;
-
-        MutableBoolean(boolean value) {
-            this.value = value;
-        }
-
-        void setValue(boolean value) {
-            this.value = value;
-        }
-
-        boolean booleanValue() {
-            return value;
-        }
-    }
 
     @TestTemplate
     void test_getdate_in_view(CallContext context) {
@@ -69,10 +55,19 @@ public class TestSimpleCases implements ScriptTest {
     }
 
     @TestTemplate
+    void testInsertWithSequence(CallContext context) {
+        UsesequenceCursor c = new UsesequenceCursor(context);
+        c.setId(100);
+        c.insert();
+        //A value is provided by the sequence
+        assertTrue(c.getVal() > 0);
+    }
+
+    @TestTemplate
     void test_triggers_on_sys_cursors(CallContext context) {
         LogCursor c = new LogCursor(context);
-        MutableBoolean isPreDeleteDone = new MutableBoolean(false);
-        MutableBoolean isPostDeleteDone = new MutableBoolean(false);
+        AtomicBoolean isPreDeleteDone = new AtomicBoolean(false);
+        AtomicBoolean isPostDeleteDone = new AtomicBoolean(false);
 
         LogCursor.onPreInsert(context.getCelesta(), logCursor ->
                 logCursor.setTablename("getDateForView"));
@@ -83,11 +78,11 @@ public class TestSimpleCases implements ScriptTest {
         LogCursor.onPostUpdate(context.getCelesta(), logCursor ->
                 logCursor.setSessionid("2"));
         LogCursor.onPreDelete(context.getCelesta(), logCursor -> {
-            isPreDeleteDone.setValue(true);
+            isPreDeleteDone.set(true);
             logCursor.setTablename("table2");
         });
         LogCursor.onPostDelete(context.getCelesta(), logCursor -> {
-            isPostDeleteDone.setValue(true);
+            isPostDeleteDone.set(true);
             logCursor.setSessionid("2");
         });
 
@@ -106,20 +101,20 @@ public class TestSimpleCases implements ScriptTest {
         assertEquals("zeroInsert", c.getTablename());
         assertEquals("2", c.getSessionid());
 
-        assertFalse(isPreDeleteDone.booleanValue());
-        assertFalse(isPostDeleteDone.booleanValue());
+        assertFalse(isPreDeleteDone.get());
+        assertFalse(isPostDeleteDone.get());
 
         c.delete();
 
-        assertTrue(isPreDeleteDone.booleanValue());
-        assertTrue(isPostDeleteDone.booleanValue());
+        assertTrue(isPreDeleteDone.get());
+        assertTrue(isPostDeleteDone.get());
     }
 
     @TestTemplate
     void test_triggers_on_gen_cursors(CallContext context) {
         ForTriggersCursor c = new ForTriggersCursor(context);
-        MutableBoolean isPreDeleteDone = new MutableBoolean(false);
-        MutableBoolean isPostDeleteDone = new MutableBoolean(false);
+        AtomicBoolean isPreDeleteDone = new AtomicBoolean(false);
+        AtomicBoolean isPostDeleteDone = new AtomicBoolean(false);
 
         ForTriggersCursor.onPreInsert(context.getCelesta(), forTriggersCursor -> {
             CustomSequence s = new CustomSequence(forTriggersCursor.callContext());
@@ -131,8 +126,8 @@ public class TestSimpleCases implements ScriptTest {
             CustomSequence s = new CustomSequence(forTriggersCursor.callContext());
             forTriggersCursor.setId((int) s.nextValue());
         });
-        ForTriggersCursor.onPreDelete(context.getCelesta(), forTriggersCursor -> isPreDeleteDone.setValue(true));
-        ForTriggersCursor.onPostDelete(context.getCelesta(), forTriggersCursor -> isPostDeleteDone.setValue(true));
+        ForTriggersCursor.onPreDelete(context.getCelesta(), forTriggersCursor -> isPreDeleteDone.set(true));
+        ForTriggersCursor.onPostDelete(context.getCelesta(), forTriggersCursor -> isPostDeleteDone.set(true));
 
         c.insert();
 
@@ -144,15 +139,15 @@ public class TestSimpleCases implements ScriptTest {
         assertEquals(2L, c.getId().intValue());
         assertEquals(3, c.getVal().intValue());
 
-        assertFalse(isPreDeleteDone.booleanValue());
-        assertFalse(isPostDeleteDone.booleanValue());
+        assertFalse(isPreDeleteDone.get());
+        assertFalse(isPostDeleteDone.get());
 
         c.setId(1);
 
         c.delete();
 
-        assertTrue(isPreDeleteDone.booleanValue());
-        assertTrue(isPostDeleteDone.booleanValue());
+        assertTrue(isPreDeleteDone.get());
+        assertTrue(isPostDeleteDone.get());
     }
 
     @TestTemplate

--- a/celesta-test/src/test/java/ru/curs/celesta/script/TestSimpleCases.java
+++ b/celesta-test/src/test/java/ru/curs/celesta/script/TestSimpleCases.java
@@ -6,10 +6,12 @@ import org.slf4j.LoggerFactory;
 import ru.curs.celesta.CallContext;
 import ru.curs.celesta.CelestaException;
 import ru.curs.celesta.syscursors.LogCursor;
+import simpleCases.CategoryCountCursor;
 import simpleCases.CustomSequence;
 import simpleCases.DuplicateCursor;
 import simpleCases.ForTriggersCursor;
 import simpleCases.GetDateForViewCursor;
+import simpleCases.SequenceAndMViewCursor;
 import simpleCases.SimpleTableCursor;
 import simpleCases.UsesequenceCursor;
 import simpleCases.ViewWithGetDateCursor;
@@ -61,6 +63,27 @@ public class TestSimpleCases implements ScriptTest {
         c.insert();
         //A value is provided by the sequence
         assertTrue(c.getVal() > 0);
+    }
+
+    @TestTemplate
+    void testInsertWithSequenceAndMView(CallContext context) {
+        //Specific case for MS SQL Server
+        SequenceAndMViewCursor c = new SequenceAndMViewCursor(context);
+        c.setId(1);
+        c.setCategory("A");
+        c.insert();
+        int val = c.getVal();
+        c.setId(2);
+        c.setVal(null);
+        c.setCategory("B");
+        c.insert();
+
+        //A value is provided by the sequence
+        assertTrue(val > 0);
+        assertEquals(val + 1, c.getVal());
+        CategoryCountCursor ccc = new CategoryCountCursor(context);
+        ccc.get("A");
+        assertEquals(1, ccc.getCnt());
     }
 
     @TestTemplate

--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
                             <arg>-Xlint:overrides</arg>
                             <arg>-Xlint:empty</arg>
                             <arg>-Xlint:cast</arg>
-                            <!--<arg>-Werror</arg>-->
+                            <arg>-Werror</arg>
                         </compilerArgs>
                     </configuration>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
                             <arg>-Xlint:overrides</arg>
                             <arg>-Xlint:empty</arg>
                             <arg>-Xlint:cast</arg>
-                            <arg>-Werror</arg>
+                            <!--<arg>-Werror</arg>-->
                         </compilerArgs>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
## Overview

When inserting to a table which has autoincremented field which is not a primary key, in some backends the following occurs:

```
java.util.NoSuchElementException: No value present
  at java.base/java.util.Optional.get(Optional.java:143)
  at ru.curs.celesta.dbutils.adaptors.H2Adaptor.getCurrentIdent(H2Adaptor.java:101)
  at ru.curs.celesta.dbutils.Cursor.tryInsert(Cursor.java:256)
  at ru.curs.celesta.dbutils.Cursor.insert(Cursor.java:196)
```

---

### Checklist

- [x] Change is covered by automated tests.
- [ ] JavaDoc / User Guide is updated.
- [x] CI builds pass.
- [x] PR is tagged.
