### PR TITLE
Bugfix:  changing the scale of the decimal field

### DIFF
--- a/celesta-core/src/main/java/ru/curs/celesta/dbutils/adaptors/ddl/FirebirdDdlGenerator.java
+++ b/celesta-core/src/main/java/ru/curs/celesta/dbutils/adaptors/ddl/FirebirdDdlGenerator.java
@@ -1033,7 +1033,7 @@ public final class FirebirdDdlGenerator extends DdlGenerator {
 
         } else if (c.getClass() == DecimalColumn.class) {
             DecimalColumn dc = (DecimalColumn) c;
-            if (dc.getPrecision() != actual.getLength() || dc.getScale() != dc.getScale()) {
+            if (dc.getPrecision() != actual.getLength() || dc.getScale() != actual.getScale()) {
                 result.addAll(this.updateColTypeViaTempColumn(c, actual));
             }
         }

--- a/celesta-core/src/main/java/ru/curs/celesta/dbutils/adaptors/ddl/H2DdlGenerator.java
+++ b/celesta-core/src/main/java/ru/curs/celesta/dbutils/adaptors/ddl/H2DdlGenerator.java
@@ -145,7 +145,7 @@ public final class H2DdlGenerator extends OpenSourceDdlGenerator {
             }
         } else if (c.getClass() == DecimalColumn.class) {
             DecimalColumn dc = (DecimalColumn) c;
-            if (dc.getPrecision() != actual.getLength() || dc.getScale() != dc.getScale()) {
+            if (dc.getPrecision() != actual.getLength() || dc.getScale() != actual.getScale()) {
                 sqlList.add(alterSql);
             }
         }

--- a/celesta-core/src/main/java/ru/curs/celesta/dbutils/adaptors/ddl/PostgresDdlGenerator.java
+++ b/celesta-core/src/main/java/ru/curs/celesta/dbutils/adaptors/ddl/PostgresDdlGenerator.java
@@ -168,7 +168,7 @@ public final class PostgresDdlGenerator extends OpenSourceDdlGenerator {
             }
         } else if (c.getClass() == DecimalColumn.class) {
             DecimalColumn dc = (DecimalColumn) c;
-            if (dc.getPrecision() != actual.getLength() || dc.getScale() != dc.getScale()) {
+            if (dc.getPrecision() != actual.getLength() || dc.getScale() != actual.getScale()) {
                 sqlList.add(alterSql.toString());
             }
         }

--- a/celesta-core/src/main/java/ru/curs/celesta/score/AbstractView.java
+++ b/celesta-core/src/main/java/ru/curs/celesta/score/AbstractView.java
@@ -106,7 +106,7 @@ public abstract class AbstractView extends DataGrainElement {
                     current[j].assertType(first[j].getMeta().getColumnType());
                     first[j].getMeta().setNullable(
                             first[j].getMeta().isNullable()
-                                    | current[j].getMeta().isNullable());
+                                    || current[j].getMeta().isNullable());
                 } catch (ParseException e) {
                     throw new ParseException(
                             String.format("UNION types in %s '%s.%s' must match. %s",

--- a/celesta-maven-plugin/src/main/java/ru/curs/celesta/plugin/maven/AbstractGenScoreResourcesMojo.java
+++ b/celesta-maven-plugin/src/main/java/ru/curs/celesta/plugin/maven/AbstractGenScoreResourcesMojo.java
@@ -87,9 +87,6 @@ abstract class AbstractGenScoreResourcesMojo extends AbstractCelestaMojo {
 
         for (GrainSourceBag gs : grainSources) {
             Path to = gs.resolve(resourcesRootPath);
-            if (to == null) {
-                continue;
-            }
 
             if (!tos.add(to)) {
                 throw new MojoExecutionException(

--- a/celesta-test/src/test/java/ru/curs/celesta/dbutils/adaptors/AbstractAdaptorTest.java
+++ b/celesta-test/src/test/java/ru/curs/celesta/dbutils/adaptors/AbstractAdaptorTest.java
@@ -1667,6 +1667,22 @@ public abstract class AbstractAdaptorTest {
     }
 
     @Test
+    void testModifyDecimalColumnScale() throws Exception {
+        // f12 decimal(11, 7),
+        DecimalColumn col = (DecimalColumn) t.getColumn("f12");
+        DbColumnInfo c = dba.getColumnInfo(conn, col);
+        assertEquals("f12", c.getName());
+        assertSame(DecimalColumn.class, c.getType());
+        assertEquals(11, c.getLength());
+        assertEquals(7, c.getScale());
+        col.setScale(9);
+        dba.updateColumn(conn, col, c);
+        c = dba.getColumnInfo(conn, col);
+        assertEquals(11, c.getLength());
+        assertEquals(9, c.getScale());
+    }
+
+    @Test
     void testColumnUpdateWithDefaultSequence() throws Exception {
         Grain g = score.getGrain(GRAIN_NAME);
         SequenceElement sequence = g.getElement("testSequence", SequenceElement.class);


### PR DESCRIPTION
## Overview

Currently, if only a scale of the decimal field is changed, for H2 and some other backends the migration doesnt start

---

### Checklist

- [X] Change is covered by automated tests.
- [NA] JavaDoc / User Guide is updated.
- [X] PR is tagged.
